### PR TITLE
Update URLs, and allow supplying subcription key via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,72 @@
-# Project
+# Planetary Computer SDK for Python
 
-> This repo has been populated by an initial template to help get you started. Please
-> make sure to update the content to build a great experience for community-building.
+Python library for interacting with the Microsoft Planetary Computer.
 
-As the maintainer of this project, please make a few updates:
+## Installation
 
-- Improving this README.MD file to provide a great experience
-- Updating SUPPORT.MD with content about this project's support experience
-- Understanding the security reporting process in SECURITY.MD
-- Remove this section from the README
+```python
+pip install planetarycomputer
+```
+
+If you have an API subscription key, you may provide it to the library by using the included configuration CLI:
+
+```bash
+planetarycomputer configure
+```
+
+Alternatively, a subscription key may be provided by specifying it in the `PC_SDK_SUBSCRIPTION_KEY` environment variable. A subcription key is not required for interacting with the service, however having one in place allows for less restricted rate limiting.
+
+
+## Development
+
+The following steps may be followed in order to develop locally:
+
+```bash
+## Create and activate venv
+python3 -m venv env
+source env/bin/activate
+
+## Install requirements
+python3 -m pip install -r requirements.txt
+python3 -m pip install -r requirements-dev.txt
+
+## Install locally
+pip install -e .
+
+## Format code
+./scripts/format
+
+## Run tests
+./scripts/test
+```
+
+
+## Usage
+
+This library currently assists with signing Azure Blob Storage URLs, both within PySTAC assets, and by providing raw URLs. The following examples demonstrate both of these use cases:
+
+```python
+import pystac
+import planetary_computer as pc
+
+raw_item: pystac.Item = ...
+item: pystac.Item = pc.sign_assets(raw_item)
+
+# Now use the item however you want. All appropriate assets are signed for read access.
+```
+
+```python
+import planetary_computer as pc
+import pystac
+
+item: pystac.Item = ...  # Landsat item
+
+b4_href = pc.sign(item.assets['SR_B4'].href)
+
+with rasterio.open(b4_href) as ds:
+   ...
+```
+
 
 ## Contributing
 
@@ -26,8 +84,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,25 +1,11 @@
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/spot](https://aka.ms/spot). CSS will work with/help you to determine next steps. More details also available at [aka.ms/onboardsupport](https://aka.ms/onboardsupport).
-- **Not sure?** Fill out a SPOT intake as though the answer were "Yes". CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
-
 # Support
 
-## How to file issues and get help  
+## How to file issues and get help
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing
+issues before filing new issues to avoid duplicates.  For new issues, file your bug or
 feature request as a new Issue.
 
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
-
-## Microsoft Support Policy  
+## Microsoft Support Policy
 
 Support for this **PROJECT or PRODUCT** is limited to the resources listed above.

--- a/planetary_computer/__init__.py
+++ b/planetary_computer/__init__.py
@@ -11,10 +11,7 @@ import requests
 import pystac
 
 
-# TODO: change this endpoint to production service when available
-SAS_TOKEN_ENDPOINT = (
-    "https://pct-pqe-westeurope-azavea-apim.azure-api.net/data/v1/sas-token"
-)
+SAS_TOKEN_ENDPOINT = "https://planetarycomputer.microsoft.com/data/v1/token"
 
 # Cache of signing requests so we can reuse them
 # Key is the signing URL, value is the SAS token
@@ -86,9 +83,12 @@ def sign(unsigned_url: str) -> str:
     account, container = parse_blob_url(unsigned_url)
     signing_url = f"{SAS_TOKEN_ENDPOINT}/{account}/{container}"
     token = TOKEN_CACHE.get(signing_url)
+
     if not token or token_expired(token):
         response = requests.get(signing_url)
         response.raise_for_status()
+        print(f"resp: {response.json()}")
+
         token = response.json()["token"]
         if not token:
             raise ValueError(f"No token found in response: {response.json()}")

--- a/planetary_computer/models.py
+++ b/planetary_computer/models.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timezone
+
+
+from pydantic import BaseModel, Field
+from pystac.utils import datetime_to_str
+
+
+class SASBase(BaseModel):
+    """Base model for responses. Include expiry, use RFC339 datetime"""
+
+    expiry: datetime = Field(alias="msft:expiry")
+
+    class Config:
+        json_encoders = {datetime: datetime_to_str}
+        allow_population_by_field_name = True
+
+
+class SignedLink(SASBase):
+    """Signed SAS URL response"""
+
+    href: str
+
+
+class SASToken(SASBase):
+    """SAS Token response"""
+
+    token: str
+
+    def sign(self, href: str) -> SignedLink:
+        """Signs an href with this token"""
+        return SignedLink(href=f"{href}?{self.token}", expiry=self.expiry)
+
+    def ttl(self) -> float:
+        """Number of seconds the token is still valid for"""
+        return (self.expiry - datetime.now(timezone.utc)).total_seconds()

--- a/planetary_computer/scripts/cli.py
+++ b/planetary_computer/scripts/cli.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import click
+
+
+@click.group(help="Microsoft Planetary Computer CLI")
+def app() -> None:
+    """Click group for planetarycomputer subcommands"""
+    pass
+
+
+@app.command()
+@click.option(
+    "--subscription_key",
+    prompt="Please enter your API subscription key",
+    help="Your API subscription key",
+)
+def configure(subscription_key: str) -> None:
+    """Configure the planetarycomputer library"""
+    settings_dir = Path("~/.planetarycomputer").expanduser()
+    settings_dir.mkdir(exist_ok=True)
+    with (settings_dir / "settings.env").open(mode="w") as settings_file:
+        settings_file.write(f"PC_SDK_SUBSCRIPTION_KEY={subscription_key}\n")

--- a/planetary_computer/settings.py
+++ b/planetary_computer/settings.py
@@ -1,0 +1,23 @@
+import pydantic
+
+
+class Settings(pydantic.BaseSettings):
+    """PC SDK configuration settings
+
+    Settings defined here are attempted to be read in two ways, in this order:
+      * environment variables
+      * environment file: ~/.planetarycomputer/settings.env
+
+    That is, any settings defined via environment variables will take precendence
+    over settings defined in the environment file, so can be used to override.
+
+    All settings are prefixed with `PC_SDK_`
+    """
+
+    # PC_SDK_SUBSCRIPTION_KEY: subcription key to send along with token
+    # requests. If present, allows less restricted rate limiting.
+    subscription_key: str
+
+    class Config:
+        env_file = "~/.planetarycomputer/settings.env"
+        env_prefix = "PC_SDK_"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black==20.8b1
 flake8==3.8.4
 ipdb==0.13.7
 mypy==0.790
+setuptools==56.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+click==7.1.2
 pydantic[dotenv]==1.8.1
 pystac==0.5.6
 pytz==2021.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic==1.8.1
+pydantic[dotenv]==1.8.1
 pystac==0.5.6
 pytz==2021.1
 requests==2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pydantic==1.8.1
 pystac==0.5.6
 pytz==2021.1
 requests==2.25.1

--- a/scripts/test
+++ b/scripts/test
@@ -19,7 +19,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage;
     else
         echo "Running mypy..."
-        mypy planetary_computer
+        mypy planetary_computer tests
 
         echo "Running black..."
         black --check planetary_computer tests

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,5 @@ setup(name=name,
       author_email="planetarycomputer@microsoft.com",
       packages=find_namespace_packages(),
       include_package_data=False,
+      entry_points={"console_scripts": ["planetarycomputer=planetary_computer.scripts.cli:app"]},
       install_requires=install_requires)

--- a/tests/data-files/sample-item.json
+++ b/tests/data-files/sample-item.json
@@ -55,7 +55,7 @@
     "assets":{
         "image":{
             "title":"RGBIR COG tile",
-            "href":"https://kennytestmspc.blob.core.windows.net/ktm/01.tif",
+            "href":"https://naipeuwest.blob.core.windows.net/naip/01.tif",
             "type":"image/tiff; application=geotiff; profile=cloud-optimized",
             "roles":[
                 "data"
@@ -78,7 +78,7 @@
         },
         "metadata":{
             "title":"FGDC Metdata",
-            "href":"https://kennytestmspc.blob.core.windows.net/ktm/01.txt",
+            "href":"https://naipeuwest.blob.core.windows.net/naip/01.txt",
             "type":"text/plain",
             "roles":[
                 "metadata"
@@ -86,7 +86,7 @@
         },
         "thumbnail":{
             "title":"Thumbnail",
-            "href":"https://kennytestmspc.blob.core.windows.net/ktm/01.jpg",
+            "href":"https://naipeuwest.blob.core.windows.net/naip/01.jpg",
             "type":"image/jpeg",
             "roles":[
                 "thumbnail"

--- a/tests/test_sign_assets.py
+++ b/tests/test_sign_assets.py
@@ -6,9 +6,8 @@ from urllib.parse import parse_qs, urlparse
 import planetary_computer as pc
 import pystac
 
-# TODO: change these, and associated data URLs to production service when available
-ACCOUNT_NAME = "kennytestmspc"
-CONTAINER_NAME = "ktm"
+ACCOUNT_NAME = "naipeuwest"
+CONTAINER_NAME = "naip"
 
 EXP_IMAGE = f"https://{ACCOUNT_NAME}.blob.core.windows.net/{CONTAINER_NAME}/01.tif"
 EXP_METADATA = f"https://{ACCOUNT_NAME}.blob.core.windows.net/{CONTAINER_NAME}/01.txt"

--- a/tests/test_sign_assets.py
+++ b/tests/test_sign_assets.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import planetary_computer as pc
 import pystac
 
+
 ACCOUNT_NAME = "naipeuwest"
 CONTAINER_NAME = "naip"
 
@@ -24,22 +25,22 @@ def get_sample_item() -> pystac.Item:
 
 
 class TestSignAssests(unittest.TestCase):
-    def assertSignedUrl(self, signed_url: str):
+    def assertSignedUrl(self, signed_url: str) -> None:
         # Ensure the signed item has an "se" URL parameter added to it,
         # which indicates it has been signed
         parsed_url = urlparse(signed_url)
         query_params = parse_qs(parsed_url.query)
         self.assertIsNotNone(query_params["se"])
 
-    def test_parse_blob_url(self):
+    def test_parse_blob_url(self) -> None:
         account, container = pc.parse_blob_url(EXP_IMAGE)
         self.assertEqual(ACCOUNT_NAME, account)
         self.assertEqual(CONTAINER_NAME, container)
 
-    def test_signed_url(self):
-        self.assertSignedUrl(pc.sign(EXP_IMAGE))
+    def test_signed_url(self) -> None:
+        self.assertSignedUrl(pc.sign(EXP_IMAGE).href)
 
-    def test_unsigned_assets(self):
+    def test_unsigned_assets(self) -> None:
         item = get_sample_item()
 
         # Simple test to ensure the sample image has the data we're expecting
@@ -47,7 +48,7 @@ class TestSignAssests(unittest.TestCase):
         self.assertEqual(EXP_METADATA, item.assets["metadata"].href)
         self.assertEqual(EXP_THUMBNAIL, item.assets["thumbnail"].href)
 
-    def test_signed_assets(self):
+    def test_signed_assets(self) -> None:
         unsigned_item = get_sample_item()
         signed_item = pc.sign_assets(unsigned_item)
 


### PR DESCRIPTION
## Overview

This PR switches out the test endpoint and container URLs for the production versions, and makes use of the new `expiry` field returned in the SAS token response.

I also added the ability for a user to pass along an API subscription key on token requests. This is done by setting `PC_SDK_SUBSCRIPTION_KEY` as either an environment variable, or in the file `~/.planetarycomputer/settings.env`. The environment variable takes precedence. If this variable is supplied, the appropriate header will be added to token requests. A simple CLI app has also been added here which allows for easily setting of this variable.

## Notes

I pulled in the SAS-related models from the Planetary Computer query engine. Once this is published to PyPI, it will probably be a good idea to import this library within the Planetary Computer query engine in order to have a single source for these models.

## Testing
To set up the repo for development and run tests, you can do the following:
```bash
## Create and activate venv
python3 -m venv env
source env/bin/activate

## Install requirements
python3 -m pip install -r requirements.txt
python3 -m pip install -r requirements-dev.txt

## Install locally
pip install -e .

## Run tests
./scripts/test

## Run the CLI and supply a subscription key
planetarycomputer configure

## Ensure the subscription key is in the appropriate place
cat ~/.planetarycomputer/settings.env
```

Pinging @lossyrob for review