### PR TITLE
Add function to set API subscription token

### DIFF
--- a/planetary_computer/__init__.py
+++ b/planetary_computer/__init__.py
@@ -2,3 +2,4 @@
 # flake8:noqa
 
 from planetary_computer.sas import sign, sign_assets  # type:ignore
+from planetary_computer.settings import set_subscription_key  # type:ignore

--- a/planetary_computer/settings.py
+++ b/planetary_computer/settings.py
@@ -37,3 +37,16 @@ class Settings(pydantic.BaseSettings):
     @lru_cache(maxsize=1)
     def get() -> "Settings":
         return Settings()
+
+
+def set_subscription_key(key: str) -> None:
+    """Sets the Planetary Computer API subscription key to use
+    within the process that loaded this module. Ths does not write
+    to the settings file.
+
+    Args:
+      key: The Planetary Computer API subscription key to use
+        for methods inside this library that can utilize the key,
+        such as SAS token generation.
+    """
+    Settings.get().subscription_key = key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-click==7.1.2
-pydantic[dotenv]==1.8.1
-pystac==0.5.6
-pytz==2021.1
-requests==2.25.1
+click>=7.1
+pydantic[dotenv]>=1.7.3
+pystac>=0.5.6,<0.6
+pytz>=2020.5
+requests>=2.25.1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,17 @@
+import os
+import unittest
+
+import planetary_computer as pc
+from planetary_computer.settings import SETTINGS_ENV_PREFIX, Settings
+
+
+class TestSettings(unittest.TestCase):
+    def test_reads_env_var(self) -> None:
+        key_env_var = f"{SETTINGS_ENV_PREFIX}_SUBSCRIPTION_KEY"
+        old_key = os.getenv(key_env_var)
+        try:
+            pc.set_subscription_key("PHILLY")
+            self.assertEqual(Settings.get().subscription_key, "PHILLY")
+        finally:
+            if old_key:
+                os.environ[key_env_var] = old_key


### PR DESCRIPTION
This PR adds a function to set the API subscription token through a Python call.

It also relaxes the version restrictions on dependencies to avoid situations where pinned versions conflict with an existing user environment.