### PR TITLE
Change pc.sign to return a url; add pc.sign_link to get SignedLink

### DIFF
--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -12,9 +12,10 @@ from planetary_computer.settings import Settings
 
 
 class SASBase(BaseModel):
-    """Base model for responses. Include expiry, use RFC339 datetime"""
+    """Base model for responses."""
 
     expiry: datetime = Field(alias="msft:expiry")
+    """RFC339 datetime format of the time this token will expire"""
 
     class Config:
         json_encoders = {datetime: datetime_to_str}
@@ -25,12 +26,15 @@ class SignedLink(SASBase):
     """Signed SAS URL response"""
 
     href: str
+    """The HREF in the format of a URL that can be used in HTTP GET operations"""
 
 
 class SASToken(SASBase):
     """SAS Token response"""
 
     token: str
+    """The Shared Access (SAS) Token that can be used to access the data
+    in, for example, Azure's Python SDK"""
 
     def sign(self, href: str) -> SignedLink:
         """Signs an href with this token"""
@@ -46,22 +50,40 @@ class SASToken(SASBase):
 TOKEN_CACHE: Dict[str, SASToken] = {}
 
 
-def sign(unsigned_url: str) -> SignedLink:
-    """Sign a blob URL
+def sign(url: str) -> str:
+    """Sign a URL with a Shared Access (SAS)
+    Token, which allows for read access.
 
     Parameters
     ----------
-    unsigned_url: str
-        URL to a blob that need to be signed
+    url (str): The HREF of the asset in the format of a URL.
+        This can be found on STAC Item's Asset 'href' value.
 
     Returns
     -------
-    The signed URL
+    The signed HREF that permits read access to the asset.
+    """
+    link = sign_link(url)
+    return link.href
+
+
+def sign_link(url: str) -> SignedLink:
+    """Sign a URL with a Shared Access (SAS) Token, which allows for read access.
+
+    Args:
+        url (str): The HREF of the asset in the format of a URL.
+            This can be found on STAC Item's Asset 'href'
+            value.
+
+    Returns:
+        SignedLink: An object that contains the signed HREF
+        in the format of a URL and the expiry time, which
+        is when the HREF will no longer permit read access.
     """
     settings = Settings.get()
-    account, container = parse_blob_url(unsigned_url)
-    signing_url = f"{settings.sas_url}/{account}/{container}"
-    token = TOKEN_CACHE.get(signing_url)
+    account, container = parse_blob_url(url)
+    token_request_url = f"{settings.sas_url}/{account}/{container}"
+    token = TOKEN_CACHE.get(token_request_url)
 
     # Refresh the token if there's less than a minute remaining,
     # in order to give a small amount of buffer
@@ -71,28 +93,28 @@ def sign(unsigned_url: str) -> SignedLink:
             if settings.subscription_key
             else None
         )
-        response = requests.get(signing_url, headers=headers)
+        response = requests.get(token_request_url, headers=headers)
         response.raise_for_status()
         token = SASToken(**response.json())
         if not token:
             raise ValueError(f"No token found in response: {response.json()}")
-        TOKEN_CACHE[signing_url] = token
-    return token.sign(unsigned_url)
+        TOKEN_CACHE[token_request_url] = token
+    return token.sign(url)
 
 
-def sign_assets(unsigned_item: pystac.Item) -> pystac.Item:
+def sign_assets(item: pystac.Item) -> pystac.Item:
     """Sign all assets within a PySTAC item
 
-    Parameters
-    ----------
-    unsigned_item : pystac.Item
-        The PySTAC item containing assets that need to be signed
+    Args:
+        item (pystac.Item): The Item whose assets that will be signed
 
-    Returns
-    -------
-    A new copy of the PySTAC item where all assets have been signed
+    Returns:
+        pystac.Item: A new copy of the Item where all assets HREFs have
+        been replaced with a signed version. In addition, a "msft:expiry"
+        property is added to the Item properties indicating the earliest
+        expiry time for any assets that were signed.
     """
-    signed_item = unsigned_item.clone()
+    signed_item = item.clone()
     for key in signed_item.assets:
-        signed_item.assets[key].href = sign(signed_item.assets[key].href).href
+        signed_item.assets[key].href = sign(signed_item.assets[key].href)
     return signed_item

--- a/tests/test_sign_assets.py
+++ b/tests/test_sign_assets.py
@@ -3,6 +3,8 @@ import json
 import unittest
 from urllib.parse import parse_qs, urlparse
 
+import requests
+
 import planetary_computer as pc
 from planetary_computer.utils import parse_blob_url
 import pystac
@@ -15,6 +17,12 @@ EXP_IMAGE = f"https://{ACCOUNT_NAME}.blob.core.windows.net/{CONTAINER_NAME}/01.t
 EXP_METADATA = f"https://{ACCOUNT_NAME}.blob.core.windows.net/{CONTAINER_NAME}/01.txt"
 EXP_THUMBNAIL = f"https://{ACCOUNT_NAME}.blob.core.windows.net/{CONTAINER_NAME}/01.jpg"
 
+SENTINEL_THUMBNAIL = (
+    "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/10/T/ET/2020/10/02/"
+    "S2B_MSIL2A_20201002T191229_N0212_R056_T10TET_20201004T193349.SAFE"
+    "/GRANULE/L2A_T10TET_A018672_20201002T192031/QI_DATA/T10TET_20201002T191229_PVI.tif"
+)
+
 
 def get_sample_item() -> pystac.Item:
     file_path = os.path.abspath(
@@ -26,10 +34,10 @@ def get_sample_item() -> pystac.Item:
 
 
 class TestSignAssests(unittest.TestCase):
-    def assertSignedUrl(self, signed_url: str) -> None:
+    def assertSigned(self, url: str) -> None:
         # Ensure the signed item has an "se" URL parameter added to it,
         # which indicates it has been signed
-        parsed_url = urlparse(signed_url)
+        parsed_url = urlparse(url)
         query_params = parse_qs(parsed_url.query)
         self.assertIsNotNone(query_params["se"])
 
@@ -39,7 +47,7 @@ class TestSignAssests(unittest.TestCase):
         self.assertEqual(CONTAINER_NAME, container)
 
     def test_signed_url(self) -> None:
-        self.assertSignedUrl(pc.sign(EXP_IMAGE).href)
+        self.assertSigned(pc.sign(EXP_IMAGE))
 
     def test_unsigned_assets(self) -> None:
         item = get_sample_item()
@@ -57,4 +65,9 @@ class TestSignAssests(unittest.TestCase):
         for key in ["image", "metadata", "thumbnail"]:
             signed_url = signed_item.assets[key].href
             self.assertNotEqual(unsigned_item.assets[key].href, signed_url)
-            self.assertSignedUrl(signed_url)
+            self.assertSigned(signed_url)
+
+    def test_read_signed_asset(self) -> None:
+        signed_href = pc.sign(SENTINEL_THUMBNAIL)
+        r = requests.get(signed_href)
+        self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
This PR changes the API such that `pc.sign` returns a signed URL directly instead of a `SignedLink` object. A `sign_link` was added to return the `SignLink` if needed, which will include the expiry time information.

Also the docstrings were changed to follow the same docstring format in PySTAC and edited. A test was created to ensure that we get a 200 response for reading a signed asset that is otherwise private (a sentinel-2-l2a thumbnail).