### PR TITLE
Handle non-blob storage assets

### DIFF
--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -19,6 +19,8 @@ def parse_blob_url(parsed_url: ParseResult) -> Tuple[str, str]:
         path_blob = parsed_url.path.lstrip("/").split("/", 1)
         container_name = path_blob[-2]
     except Exception as failed_parse:
-        raise ValueError(f"Invalid blob URL: {urlunparse(parsed_url)}") from failed_parse
+        raise ValueError(
+            f"Invalid blob URL: {urlunparse(parsed_url)}"
+        ) from failed_parse
 
     return account_name, container_name

--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -1,8 +1,8 @@
 from typing import Tuple
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlunparse
 
 
-def parse_blob_url(url: str) -> Tuple[str, str]:
+def parse_blob_url(parsed_url: ParseResult) -> Tuple[str, str]:
     """Find the account and container in a blob URL
 
     Parameters
@@ -15,11 +15,10 @@ def parse_blob_url(url: str) -> Tuple[str, str]:
     Tuple of the account name and container name
     """
     try:
-        parsed_url = urlparse(url.rstrip("/"))
         account_name = parsed_url.netloc.split(".")[0]
         path_blob = parsed_url.path.lstrip("/").split("/", 1)
         container_name = path_blob[-2]
     except Exception as failed_parse:
-        raise ValueError(f"Invalid blob URL: {url}") from failed_parse
+        raise ValueError(f"Invalid blob URL: {urlunparse(parsed_url)}") from failed_parse
 
     return account_name, container_name

--- a/tests/data-files/sample-item.json
+++ b/tests/data-files/sample-item.json
@@ -51,7 +51,7 @@
         -85.625,
         31.0
     ],
-    "stac_version":"1.0.0-beta.2",
+    "stac_version":"1.0.0",
     "assets":{
         "image":{
             "title":"RGBIR COG tile",
@@ -91,6 +91,18 @@
             "roles":[
                 "thumbnail"
             ]
+        },
+        "tilejson": {
+            "title": "TileJSON with default rendering",
+            "href": "https://planetarycomputer-staging.microsoft.com/api/data/v1/item/tilejson.json?collection=naip&items=fl_m_2608005_nw_17_060_20191215_20200113&assets=image&bidx=1,2,3",
+            "type": "application/json",
+            "roles": ["tiles"]
+        },
+        "hero": {
+            "title": "STAC logo, not in a storage account",
+            "href": "https://raw.githubusercontent.com/radiantearth/stac-site/master/images/logo/stac-030-long.png",
+            "type": "image/png",
+            "roles": ["logo"]
         }
     },
     "links": [],

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -54,7 +54,7 @@ class TestSigning(unittest.TestCase):
         self.assertIsNotNone(query_params["se"])
 
     def test_parse_blob_url(self) -> None:
-        account, container = parse_blob_url(EXP_IMAGE)
+        account, container = parse_blob_url(urlparse(EXP_IMAGE))
         self.assertEqual(ACCOUNT_NAME, account)
         self.assertEqual(CONTAINER_NAME, container)
 


### PR DESCRIPTION
This updates `sign` to only sign URLs that look like blob storage URLs (the domain ends with `.blob.core.windows.net`).

Closes https://github.com/microsoft/planetary-computer-sdk-for-python/issues/16