### PR TITLE
API Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,7 @@
 ## Deprecations
 
 * `sign_assets` is deprecated. Use `sign_item` instead.
+
+## Bug Fixes
+
+* `sign_item` now handles items with assets containing links to files outside of blob storage by returning the asset unchanged. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# 0.3.0
+
+## New Features
+
+* `sign` now works on strings, `pystac.Item`, `pystac.Asset`, `pystac.ItemCollection`, and `pystac_client.ItemSearch` instances.
+* Added top-level methods `sign_item`, `sign_asset`, and `sign_item_collection` to directly sign objects of those types.
+
+## Deprecations
+
+* `sign_assets` is deprecated. Use `sign_item` instead.

--- a/planetary_computer/__init__.py
+++ b/planetary_computer/__init__.py
@@ -1,8 +1,15 @@
 """Planetary Computer Python SDK"""
 # flake8:noqa
 
-from planetary_computer.sas import sign, sign_url, sign_item, sign_assets, sign_asset, sign_item_collection
-from planetary_computer.settings import set_subscription_key 
+from planetary_computer.sas import (
+    sign,
+    sign_url,
+    sign_item,
+    sign_assets,
+    sign_asset,
+    sign_item_collection,
+)
+from planetary_computer.settings import set_subscription_key
 
 
 __all__ = [

--- a/planetary_computer/__init__.py
+++ b/planetary_computer/__init__.py
@@ -1,5 +1,16 @@
 """Planetary Computer Python SDK"""
 # flake8:noqa
 
-from planetary_computer.sas import sign  # type:ignore
-from planetary_computer.settings import set_subscription_key  # type:ignore
+from planetary_computer.sas import sign, sign_url, sign_item, sign_assets, sign_asset, sign_item_collection
+from planetary_computer.settings import set_subscription_key 
+
+
+__all__ = [
+    "set_subscription_key",
+    "sign_asset",
+    "sign_assets",
+    "sign_item_collection",
+    "sign_item",
+    "sign_url",
+    "sign",
+]

--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from typing import Any, Dict
+import warnings
 
 from functools import singledispatch
 from urllib.parse import urlparse
@@ -72,7 +73,7 @@ def sign(obj: Any) -> Any:
 
 
 @sign.register(str)
-def _sign_url(url: str) -> str:
+def sign_url(url: str) -> str:
     """Sign a URL with a Shared Access (SAS) Token, which allows for read access.
 
     Args:
@@ -111,7 +112,7 @@ def _sign_url(url: str) -> str:
 
 
 @sign.register(Item)
-def _sign_item(item: Item) -> Item:
+def sign_item(item: Item) -> Item:
     """Sign all assets within a PySTAC item
 
     Args:
@@ -130,7 +131,7 @@ def _sign_item(item: Item) -> Item:
 
 
 @sign.register(Asset)
-def _sign_asset(asset: Asset) -> Asset:
+def sign_asset(asset: Asset) -> Asset:
     """Sign a PySTAC asset
 
     Args:
@@ -145,8 +146,14 @@ def _sign_asset(asset: Asset) -> Asset:
     return signed_asset
 
 
+def sign_assets(item):
+    warnings.warn("'sign_assets' is deprecated and will be removed in a future version. Use 'sign_item' instead.", FutureWarning, stacklevel=2)
+    return sign_item(item)
+
+
+
 @sign.register(ItemCollection)
-def _sign_item_collection(item_collection: ItemCollection) -> ItemCollection:
+def sign_item_collection(item_collection: ItemCollection) -> ItemCollection:
     """Sign a PySTAC item collection
 
     Args:

--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -146,7 +146,7 @@ def sign_asset(asset: Asset) -> Asset:
     return signed_asset
 
 
-def sign_assets(item):
+def sign_assets(item: Item) -> Item:
     warnings.warn(
         "'sign_assets' is deprecated and will be removed in a future version. Use 'sign_item' instead.",
         FutureWarning,

--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -148,7 +148,8 @@ def sign_asset(asset: Asset) -> Asset:
 
 def sign_assets(item: Item) -> Item:
     warnings.warn(
-        "'sign_assets' is deprecated and will be removed in a future version. Use 'sign_item' instead.",
+        "'sign_assets' is deprecated and will be removed in a future version. Use "
+        "'sign_item' instead.",
         FutureWarning,
         stacklevel=2,
     )

--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -147,9 +147,12 @@ def sign_asset(asset: Asset) -> Asset:
 
 
 def sign_assets(item):
-    warnings.warn("'sign_assets' is deprecated and will be removed in a future version. Use 'sign_item' instead.", FutureWarning, stacklevel=2)
+    warnings.warn(
+        "'sign_assets' is deprecated and will be removed in a future version. Use 'sign_item' instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     return sign_item(item)
-
 
 
 @sign.register(ItemCollection)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -110,9 +110,15 @@ class TestSigning(unittest.TestCase):
         with self.assertWarns(FutureWarning):
             pc.sign_assets(item)
 
-    def test_public_api(self):
+    def test_public_api(self) -> None:
         item = get_sample_item()
 
         self.assertEqual(type(pc.sign(item)), type(pc.sign_item(item)))
-        self.assertEqual(type(pc.sign(item.assets["image"])), type(pc.sign_asset(item.assets["image"])))
-        self.assertEqual(type(pc.sign(item.assets["image"].href)), type(pc.sign_url(item.assets["image"].href)))
+        self.assertEqual(
+            type(pc.sign(item.assets["image"])),
+            type(pc.sign_asset(item.assets["image"])),
+        )
+        self.assertEqual(
+            type(pc.sign(item.assets["image"].href)),
+            type(pc.sign_url(item.assets["image"].href)),
+        )

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -104,3 +104,15 @@ class TestSigning(unittest.TestCase):
         self.assertEqual(len(list(signed_item_collection)), 1)
         for signed_item in signed_item_collection:
             self.verify_signed_urls_in_item(signed_item)
+
+    def test_sign_assets_deprecated(self) -> None:
+        item = get_sample_item()
+        with self.assertWarns(FutureWarning):
+            pc.sign_assets(item)
+
+    def test_public_api(self):
+        item = get_sample_item()
+
+        self.assertEqual(type(pc.sign(item)), type(pc.sign_item(item)))
+        self.assertEqual(type(pc.sign(item.assets["image"])), type(pc.sign_asset(item.assets["image"])))
+        self.assertEqual(type(pc.sign(item.assets["image"].href)), type(pc.sign_url(item.assets["image"].href)))


### PR DESCRIPTION
* Added `sign_*` to the public API, for users wishing to bypass the
  overhead of `sign`
* Restored `sign_assets` with a deprecation
* Added a changelog