### PR TITLE
Added signing for tabular datasets

### DIFF
--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -128,8 +128,9 @@ def sign_asset(asset: Asset) -> Asset:
     if is_fsspec_asset(asset):
         account = signed_asset.properties["table:storage_options"]["account_name"]
         container = parse_adlfs_url(asset.href)
-        token = _get_token(account, container)
-        signed_asset.properties["table:storage_options"]["credential"] = token.token
+        if container:
+            token = _get_token(account, container)
+            signed_asset.properties["table:storage_options"]["credential"] = token.token
     return signed_asset
 
 

--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -11,7 +11,7 @@ from pystac.utils import datetime_to_str
 from pystac_client import ItemSearch
 
 from planetary_computer.settings import Settings
-from planetary_computer.utils import parse_blob_url
+from planetary_computer.utils import parse_blob_url, parse_adlfs_url, is_fsspec_asset
 
 
 BLOB_STORAGE_DOMAIN = ".blob.core.windows.net"
@@ -84,30 +84,12 @@ def sign_url(url: str) -> str:
     Returns:
         str: The signed HREF
     """
-    settings = Settings.get()
     parsed_url = urlparse(url.rstrip("/"))
     if not parsed_url.netloc.endswith(BLOB_STORAGE_DOMAIN):
         return url
 
     account, container = parse_blob_url(parsed_url)
-
-    token_request_url = f"{settings.sas_url}/{account}/{container}"
-    token = TOKEN_CACHE.get(token_request_url)
-
-    # Refresh the token if there's less than a minute remaining,
-    # in order to give a small amount of buffer
-    if not token or token.ttl() < 60:
-        headers = (
-            {"Ocp-Apim-Subscription-Key": settings.subscription_key}
-            if settings.subscription_key
-            else None
-        )
-        response = requests.get(token_request_url, headers=headers)
-        response.raise_for_status()
-        token = SASToken(**response.json())
-        if not token:
-            raise ValueError(f"No token found in response: {response.json()}")
-        TOKEN_CACHE[token_request_url] = token
+    token = _get_token(account, container)
     return token.sign(url).href
 
 
@@ -143,6 +125,11 @@ def sign_asset(asset: Asset) -> Asset:
     """
     signed_asset = asset.clone()
     signed_asset.href = sign(signed_asset.href)
+    if is_fsspec_asset(asset):
+        account = signed_asset.properties["table:storage_options"]["account_name"]
+        container = parse_adlfs_url(asset.href)
+        token = _get_token(account, container)
+        signed_asset.properties["table:storage_options"]["credential"] = token.token
     return signed_asset
 
 
@@ -191,3 +178,37 @@ def _search_and_sign(search: ItemSearch) -> ItemCollection:
         earliest expiry time for any assets that were signed.
     """
     return sign(search.get_all_items())
+
+
+def _get_token(account: str, container: str) -> SASToken:
+    """
+    Get a token for a container in a storage account.
+
+    This will use a token from the cache if it's present and not too close
+    to expiring. The generated token will be placed in the token cache.
+
+    Args:
+        account (str): The storage account name.
+        container (str): The storage container name.
+    Returns:
+        SasToken: the generated token
+    """
+    settings = Settings.get()
+    token_request_url = f"{settings.sas_url}/{account}/{container}"
+    token = TOKEN_CACHE.get(token_request_url)
+
+    # Refresh the token if there's less than a minute remaining,
+    # in order to give a small amount of buffer
+    if not token or token.ttl() < 60:
+        headers = (
+            {"Ocp-Apim-Subscription-Key": settings.subscription_key}
+            if settings.subscription_key
+            else None
+        )
+        response = requests.get(token_request_url, headers=headers)
+        response.raise_for_status()
+        token = SASToken(**response.json())
+        if not token:
+            raise ValueError(f"No token found in response: {response.json()}")
+        TOKEN_CACHE[token_request_url] = token
+    return token

--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -89,7 +89,7 @@ def sign_url(url: str) -> str:
         return url
 
     account, container = parse_blob_url(parsed_url)
-    token = _get_token(account, container)
+    token = get_token(account, container)
     return token.sign(url).href
 
 
@@ -129,7 +129,7 @@ def sign_asset(asset: Asset) -> Asset:
         account = signed_asset.extra_fields["table:storage_options"]["account_name"]
         container = parse_adlfs_url(asset.href)
         if container:
-            token = _get_token(account, container)
+            token = get_token(account, container)
             signed_asset.extra_fields["table:storage_options"][
                 "credential"
             ] = token.token
@@ -183,7 +183,7 @@ def _search_and_sign(search: ItemSearch) -> ItemCollection:
     return sign(search.get_all_items())
 
 
-def _get_token(account: str, container: str) -> SASToken:
+def get_token(account_name: str, container_name: str) -> SASToken:
     """
     Get a token for a container in a storage account.
 
@@ -191,13 +191,13 @@ def _get_token(account: str, container: str) -> SASToken:
     to expiring. The generated token will be placed in the token cache.
 
     Args:
-        account (str): The storage account name.
-        container (str): The storage container name.
+        account_name (str): The storage account name.
+        container_name (str): The storage container name.
     Returns:
-        SasToken: the generated token
+        SASToken: the generated token
     """
     settings = Settings.get()
-    token_request_url = f"{settings.sas_url}/{account}/{container}"
+    token_request_url = f"{settings.sas_url}/{account_name}/{container_name}"
     token = TOKEN_CACHE.get(token_request_url)
 
     # Refresh the token if there's less than a minute remaining,

--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -126,11 +126,13 @@ def sign_asset(asset: Asset) -> Asset:
     signed_asset = asset.clone()
     signed_asset.href = sign(signed_asset.href)
     if is_fsspec_asset(asset):
-        account = signed_asset.properties["table:storage_options"]["account_name"]
+        account = signed_asset.extra_fields["table:storage_options"]["account_name"]
         container = parse_adlfs_url(asset.href)
         if container:
             token = _get_token(account, container)
-            signed_asset.properties["table:storage_options"]["credential"] = token.token
+            signed_asset.extra_fields["table:storage_options"][
+                "credential"
+            ] = token.token
     return signed_asset
 
 

--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -53,4 +53,4 @@ def is_fsspec_asset(asset: pystac.Asset) -> bool:
 
     This checks if "account_name" is present in the asset's "table:storage_options" field.
     """
-    return "account_name" in asset.properties.get("table:storage_options", {})
+    return "account_name" in asset.extra_fields.get("table:storage_options", {})

--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -51,6 +51,7 @@ def is_fsspec_asset(asset: pystac.Asset) -> bool:
     """
     Determine if an Asset points to an fsspec URL.
 
-    This checks if "account_name" is present in the asset's "table:storage_options" field.
+    This checks if "account_name" is present in the asset's "table:storage_options"
+    field.
     """
     return "account_name" in asset.extra_fields.get("table:storage_options", {})

--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -1,5 +1,7 @@
-from typing import Tuple
-from urllib.parse import ParseResult, urlunparse
+from typing import Tuple, Optional
+from urllib.parse import ParseResult, urlunparse, urlparse
+
+import pystac
 
 
 def parse_blob_url(parsed_url: ParseResult) -> Tuple[str, str]:
@@ -24,3 +26,31 @@ def parse_blob_url(parsed_url: ParseResult) -> Tuple[str, str]:
         ) from failed_parse
 
     return account_name, container_name
+
+
+def parse_adlfs_url(url: str) -> Optional[str]:
+    """
+    Extract the storage container from an adlfs URL.
+
+    Parameters
+    ----------
+    url : str
+        The URL to extract the container from, if present
+
+    Returns
+    -------
+    str or None
+        Returns the container name, if present. Otherwise None is returned.
+    """
+    if url.startswith(("abfs://", "az://")):
+        return urlparse(url).netloc
+    return None
+
+
+def is_fsspec_asset(asset: pystac.Asset) -> bool:
+    """
+    Determine if an Asset points to an fsspec URL.
+
+    This checks if "account_name" is present in the asset's "table:storage_options" field.
+    """
+    return "account_name" in asset.properties.get("table:storage_options", {})

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -9,12 +9,16 @@ import requests
 
 import planetary_computer as pc
 from planetary_computer.utils import parse_blob_url, is_fsspec_asset, parse_adlfs_url
+from planetary_computer.sas import get_token, TOKEN_CACHE
 from pystac import Asset, Item, ItemCollection
 from pystac_client import ItemSearch
 
 
 ACCOUNT_NAME = "naipeuwest"
 CONTAINER_NAME = "naip"
+TOKEN_REQUEST_URL = (
+    "https://planetarycomputer.microsoft.com/api/sas/v1/token/naipeuwest/naip"
+)
 
 EXP_IMAGE = f"https://{ACCOUNT_NAME}.blob.core.windows.net/{CONTAINER_NAME}/01.tif"
 EXP_METADATA = f"https://{ACCOUNT_NAME}.blob.core.windows.net/{CONTAINER_NAME}/01.txt"
@@ -122,6 +126,15 @@ class TestSigning(unittest.TestCase):
             type(pc.sign(item.assets["image"].href)),
             type(pc.sign_url(item.assets["image"].href)),
         )
+
+    def test_get_token(self) -> None:
+        result = get_token(account_name=ACCOUNT_NAME, container_name=CONTAINER_NAME)
+        self.assertIn(TOKEN_REQUEST_URL, TOKEN_CACHE)
+        self.assertIsInstance(result.token, str)
+        self.assertEqual(result.token, TOKEN_CACHE[TOKEN_REQUEST_URL].token)
+
+        result2 = get_token(account_name=ACCOUNT_NAME, container_name=CONTAINER_NAME)
+        self.assertIs(result, result2)
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -125,7 +125,7 @@ class TestSigning(unittest.TestCase):
 
 
 class TestUtils(unittest.TestCase):
-    def test_parse_adlfs_url(self):
+    def test_parse_adlfs_url(self) -> None:
         result = parse_adlfs_url("abfs://my-container/my/path.ext")
         self.assertEqual(result, "my-container")
 
@@ -138,15 +138,16 @@ class TestUtils(unittest.TestCase):
         result = parse_adlfs_url("https://planetarycomputer.microsoft.com")
         self.assertIsNone(result)
 
-    def test_is_fsspec_url(self):
+    def test_is_fsspec_url(self) -> None:
         asset = Asset(
             "adlfs://my-container/my/path.ext",
-            properties={"table:storage_options": {"account_name": "foo"}},
+            extra_fields={"table:storage_options": {"account_name": "foo"}},
         )
         self.assertTrue(is_fsspec_asset(asset))
 
         asset = Asset(
-            "adlfs://my-container/my/path.ext", properties={"table:storage_options": {}}
+            "adlfs://my-container/my/path.ext",
+            extra_fields={"table:storage_options": {}},
         )
         self.assertFalse(is_fsspec_asset(asset))
 


### PR DESCRIPTION
This PR adds the ability to sign assets from tabular dataets.

```python
In [1]: import dask.dataframe as dd, adlfs, pystac, planetary_computer

In [2]: item = pystac.Item.from_file("../../TomAugspurger/stac-table/examples/us-census/items/cb_2020_02_anrc_500k.json")

In [3]: asset = item.assets["data"]

In [4]: asset.to_dict()
Out[4]:
{'href': 'abfs://us-census/2020/cb_2020_02_anrc_500k.parq',
 'type': 'application/x-parquet',
 'title': 'Dataset root',
 'table:storage_options': {'account_name': 'ai4edataeuwest'},
 'roles': ['data']}
```

The asset's HREF is an fsspec-compatible URL, pointing to a parquet dataset in a private storage container. Trying to read it fails by default.

```pytb
In [5]: dd.read_parquet(asset.href, storage_options=asset.properties["table:storage_options"])
---------------------------------------------------------------------------
ClientAuthenticationError                 Traceback (most recent call last)
<ipython-input-5-1dccf59b1828> in <module>
----> 1 dd.read_parquet(asset.href, storage_options=asset.properties["table:storage_options"])

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/dask/dataframe/io/parquet/core.py in read_parquet(path, columns, filters, categories, index, storage_options, engine, gather_statistics, ignore_metadata_file, split_row_groups, read_from_paths, chunksize, aggregate_files, **kwargs)
    316         gather_statistics = True
    317
--> 318     read_metadata_result = engine.read_metadata(
    319         fs,
    320         paths,

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/dask/dataframe/io/parquet/arrow.py in read_metadata(cls, fs, paths, categories, index, gather_statistics, filters, split_row_groups, read_from_paths, chunksize, aggregate_files, ignore_metadata_file, **kwargs)
    539             split_row_groups,
    540             gather_statistics,
--> 541         ) = cls._gather_metadata(
    542             paths,
    543             fs,

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/dask/dataframe/io/parquet/arrow.py in _gather_metadata(cls, paths, fs, split_row_groups, gather_statistics, filters, index, dataset_kwargs)
   1038             raise ValueError(f"Unsupported dataset_kwargs: {_dataset_kwargs.keys()}")
   1039
-> 1040         if len(paths) == 1 and fs.isdir(paths[0]):
   1041
   1042             # Use _analyze_paths to avoid relative-path

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/adlfs/spec.py in isdir(self, path)
   1317
   1318     def isdir(self, path):
-> 1319         return sync(self.loop, self._isdir, path)
   1320
   1321     async def _isdir(self, path):

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/fsspec/asyn.py in sync(loop, func, timeout, *args, **kwargs)
     67         raise FSTimeoutError
     68     if isinstance(result[0], BaseException):
---> 69         raise result[0]
     70     return result[0]
     71

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/fsspec/asyn.py in _runner(event, coro, result, timeout)
     23         coro = asyncio.wait_for(coro, timeout=timeout)
     24     try:
---> 25         result[0] = await coro
     26     except Exception as ex:
     27         result[0] = ex

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/adlfs/spec.py in _isdir(self, path)
   1339                 ) as cc:
   1340                     blob_pages = cc.list_blobs(name_starts_with=key)
-> 1341                     async for blob in blob_pages:
   1342                         if (blob["metadata"].get("is_directory", None) == "true") and (
   1343                             blob["name"] == path

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/azure/core/async_paging.py in __anext__(self)
    152         if self._page_iterator is None:
    153             self._page_iterator = self.by_page()
--> 154             return await self.__anext__()
    155         if self._page is None:
    156             # Let it raise StopAsyncIteration

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/azure/core/async_paging.py in __anext__(self)
    155         if self._page is None:
    156             # Let it raise StopAsyncIteration
--> 157             self._page = await self._page_iterator.__anext__()
    158             return await self.__anext__()
    159         try:

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/azure/core/async_paging.py in __anext__(self)
     97             raise StopAsyncIteration("End of paging")
     98         try:
---> 99             self._response = await self._get_next(self.continuation_token)
    100         except AzureError as error:
    101             if not error.continuation_token:

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/azure/storage/blob/aio/_list_blobs_helper.py in _get_next_cb(self, continuation_token)
     76                 use_location=self.location_mode)
     77         except HttpResponseError as error:
---> 78             process_storage_error(error)
     79
     80     async def _extract_data_cb(self, get_next_return):

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/azure/storage/blob/_shared/response_handlers.py in process_storage_error(storage_error)
     87     # If storage_error is one of the two then it has already been processed and serialized to the specific exception.
     88     if isinstance(storage_error, (PartialBatchErrorException, ClientAuthenticationError)):
---> 89         raise storage_error
     90     raise_error = HttpResponseError
     91     error_code = storage_error.response.headers.get('x-ms-error-code')

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/azure/storage/blob/aio/_list_blobs_helper.py in _get_next_cb(self, continuation_token)
     69     async def _get_next_cb(self, continuation_token):
     70         try:
---> 71             return await self._command(
     72                 prefix=self.prefix,
     73                 marker=continuation_token or None,

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/azure/storage/blob/_generated/aio/operations/_container_operations.py in list_blob_flat_segment(self, prefix, marker, maxresults, include, timeout, request_id_parameter, **kwargs)
   1442
   1443         if response.status_code not in [200]:
-> 1444             map_error(status_code=response.status_code, response=response, error_map=error_map)
   1445             error = self._deserialize(_models.StorageError, response)
   1446             raise HttpResponseError(response=response, model=error)

~/miniconda3/envs/planetary-computer-dev/lib/python3.8/site-packages/azure/core/exceptions.py in map_error(status_code, response, error_map)
    103         return
    104     error = error_type(response=response)
--> 105     raise error
    106
    107

ClientAuthenticationError: Operation returned an invalid status 'Server failed to authenticate the request. Please refer to the information in the www-authenticate header.'
```

So we sign the asset first

```python
In [6]: signed_asset = planetary_computer.sign(asset)

In [7]: dd.read_parquet(signed_asset.href, storage_options=signed_asset.properties["table:storage_options"])
Out[7]:
Dask DataFrame Structure:
              STATEFP  ANRCFP  ANRCNS AFFGEOID   GEOID    NAME NAMELSAD    LSAD  ALAND AWATER geometry
npartitions=1
0              object  object  object   object  object  object   object  object  int64  int64   object
11                ...     ...     ...      ...     ...     ...      ...     ...    ...    ...      ...
Dask Name: read-parquet, 1 tasks
```

This works by updating the `table:storage_options` with a `credential` whose value is a token from the API endpoint.

```
In [8]: signed_asset.to_dict()
Out[8]:
{'href': 'abfs://us-census/2020/cb_2020_02_anrc_500k.parq',
 'type': 'application/x-parquet',
 'title': 'Dataset root',
 'table:storage_options': {'account_name': 'ai4edataeuwest',
  'credential': 'st=2021-08-26T20%3A44%3A25Z...'},
 'roles': ['data']}
```