### PR TITLE
Ensure signed item's assets point back to the item (#25)

### DIFF
--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -78,9 +78,14 @@ class TestSigning(unittest.TestCase):
             signed_url = signed_item.assets[key].href
             self.assertSigned(signed_url)
 
+    def verify_asset_owner(self, signed_item: Item) -> None:
+        for asset in signed_item.assets.values():
+            self.assertIs(asset.owner, signed_item)
+
     def test_signed_assets(self) -> None:
         signed_item = pc.sign(get_sample_item())
         self.verify_signed_urls_in_item(signed_item)
+        self.verify_asset_owner(signed_item)
 
     def test_read_signed_asset(self) -> None:
         signed_href = pc.sign(SENTINEL_THUMBNAIL)


### PR DESCRIPTION
This PR fixes #25.

Basically I'm adding `_sign_asset_in_place` function, which is just a copy of the original `sign(asset: Asset)` function but with `asset.clone` step removed. `sign(item)` overload is then modified to use in-place version of asset signing since assets were already cloned.

