### PR TITLE
Sign for datacube assets

### DIFF
--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 import warnings
 
 from functools import singledispatch
@@ -138,6 +138,8 @@ def _sign_asset_in_place(asset: Asset) -> Asset:
     """
     asset.href = sign(asset.href)
     if is_fsspec_asset(asset):
+        key: Optional[str]
+
         for key in ["table:storage_options", "xarray:storage_options"]:
             if key in asset.extra_fields:
                 break

--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -138,11 +138,19 @@ def _sign_asset_in_place(asset: Asset) -> Asset:
     """
     asset.href = sign(asset.href)
     if is_fsspec_asset(asset):
-        account = asset.extra_fields["table:storage_options"]["account_name"]
-        container = parse_adlfs_url(asset.href)
-        if container:
-            token = get_token(account, container)
-            asset.extra_fields["table:storage_options"]["credential"] = token.token
+        for key in ["table:storage_options", "xarray:storage_options"]:
+            if key in asset.extra_fields:
+                break
+        else:
+            key = None
+
+        if key:
+            storage_options = asset.extra_fields[key]
+            account = storage_options.get("account_name")
+            container = parse_adlfs_url(asset.href)
+            if account and container:
+                token = get_token(account, container)
+                asset.extra_fields[key]["credential"] = token.token
     return asset
 
 

--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -54,4 +54,5 @@ def is_fsspec_asset(asset: pystac.Asset) -> bool:
     This checks if "account_name" is present in the asset's "table:storage_options"
     field.
     """
-    return "account_name" in asset.extra_fields.get("table:storage_options", {})
+    return ("account_name" in asset.extra_fields.get("table:storage_options", {}) or
+            "account_name" in asset.extra_fields.get("xarray:storage_options", {}))

--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -52,7 +52,7 @@ def is_fsspec_asset(asset: pystac.Asset) -> bool:
     Determine if an Asset points to an fsspec URL.
 
     This checks if "account_name" is present in the asset's "table:storage_options"
-    field.
+    or "xarray:storage_options" fields.
     """
     return "account_name" in asset.extra_fields.get(
         "table:storage_options", {}

--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -54,5 +54,6 @@ def is_fsspec_asset(asset: pystac.Asset) -> bool:
     This checks if "account_name" is present in the asset's "table:storage_options"
     field.
     """
-    return ("account_name" in asset.extra_fields.get("table:storage_options", {}) or
-            "account_name" in asset.extra_fields.get("xarray:storage_options", {}))
+    return "account_name" in asset.extra_fields.get(
+        "table:storage_options", {}
+    ) or "account_name" in asset.extra_fields.get("xarray:storage_options", {})

--- a/tests/data-files/sample-tabular-item.json
+++ b/tests/data-files/sample-tabular-item.json
@@ -1,0 +1,49 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "plot",
+    "properties": {
+        "table:columns": [
+            {
+                "name": "CN",
+                "type": "int64",
+                "description": "Sequence number"
+            },
+            {
+                "name": "SRV_CN",
+                "type": "int64",
+                "description": "Survey sequence number"
+            },
+            {
+                "name": "CTY_CN",
+                "type": "int64",
+                "description": "County sequence number"
+            }
+        ],
+        "datetime": "2020-06-01T00:00:00Z"
+    },
+    "geometry": null,
+    "links": [],
+    "assets": {
+        "data": {
+            "href": "abfs://cpdata/raw/fia/plot.parquet",
+            "type": "application/x-parquet",
+            "title": "Dataset root",
+            "table:storage_options": {
+                "account_name": "cpdataeuwest"
+            },
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -179.14734,
+        -14.53,
+        179.77847,
+        71.352561
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.0.0/schema.json"
+    ]
+}

--- a/tests/data-files/sample-zarr-item.json
+++ b/tests/data-files/sample-zarr-item.json
@@ -1,0 +1,632 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "terraclimate",
+    "properties": {
+        "cube:dimensions": {
+            "time": {
+                "type": "temporal",
+                "description": "time",
+                "extent": [
+                    "1958-01-01T00:00:00Z",
+                    "2019-12-01T00:00:00Z"
+                ]
+            },
+            "lon": {
+                "type": "spatial",
+                "axis": "x",
+                "description": "longitude",
+                "extent": [
+                    -179.97916666666666,
+                    179.97916666666666
+                ],
+                "reference_system": 4326
+            },
+            "lat": {
+                "type": "spatial",
+                "axis": "y",
+                "description": "latitude",
+                "extent": [
+                    -89.97916666666664,
+                    89.97916666666667
+                ],
+                "reference_system": 4326
+            }
+        },
+        "cube:variables": {
+            "aet": {
+                "type": "data",
+                "description": "Actual Evapotranspiration",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Actual Evapotranspiration",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "water_evaporation_amount",
+                    "standard_name": "water_evaporation_amount",
+                    "units": "mm"
+                }
+            },
+            "def": {
+                "type": "data",
+                "description": "Climatic Water Deficit",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Climatic Water Deficit",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "water_potential_evaporation_amount_minus_water_evaporation_amount",
+                    "standard_name": "water_potential_evaporation_amount_minus_water_evaporation_amount",
+                    "units": "mm"
+                }
+            },
+            "pdsi": {
+                "type": "data",
+                "description": "Palmer Drought Severity Index",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "unitless",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Palmer Drought Severity Index",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "palmer_drought_severity_index",
+                    "standard_name": "palmer_drought_severity_index",
+                    "units": "unitless"
+                }
+            },
+            "pet": {
+                "type": "data",
+                "description": "Reference Evapotranspiration",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Reference Evapotranspiration",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "water_potential_evaporation_amount",
+                    "standard_name": "water_potential_evaporation_amount",
+                    "units": "mm"
+                }
+            },
+            "ppt": {
+                "type": "data",
+                "description": "Accumulated Precipitation",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Accumulated Precipitation",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "precipitation_amount",
+                    "standard_name": "precipitation_amount",
+                    "units": "mm"
+                }
+            },
+            "ppt_station_influence": {
+                "type": "data",
+                "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "none",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "station_influence",
+                    "standard_name": "station_influence",
+                    "units": "none"
+                }
+            },
+            "q": {
+                "type": "data",
+                "description": "Runoff",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Runoff",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "runoff_amount",
+                    "standard_name": "runoff_amount",
+                    "units": "mm"
+                }
+            },
+            "soil": {
+                "type": "data",
+                "description": "Soil Moisture at End of Month",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Soil Moisture at End of Month",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "soil_moisture_content",
+                    "standard_name": "soil_moisture_content",
+                    "units": "mm"
+                }
+            },
+            "srad": {
+                "type": "data",
+                "description": "Downward Shortwave Radiation Flux at the Surface",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "W/m2",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Downward Shortwave Radiation Flux at the Surface",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "downwelling_shortwave_flux_in_air",
+                    "standard_name": "downwelling_shortwave_flux_in_air",
+                    "units": "W/m2"
+                }
+            },
+            "swe": {
+                "type": "data",
+                "description": "Snow Water Equivalent at End of Month",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Snow Water Equivalent at End of Month",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "liquid_water_content_of_surface_snow",
+                    "standard_name": "liquid_water_content_of_surface_snow",
+                    "units": "mm"
+                }
+            },
+            "tmax": {
+                "type": "data",
+                "description": "Maximum 2-m Temperature",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "deg C",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Maximum 2-m Temperature",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "air_temperature",
+                    "standard_name": "air_temperature",
+                    "units": "deg C"
+                }
+            },
+            "tmax_station_influence": {
+                "type": "data",
+                "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "none",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "station_influence",
+                    "standard_name": "station_influence",
+                    "units": "none"
+                }
+            },
+            "tmin": {
+                "type": "data",
+                "description": "Minimum 2-m Temperature",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "deg C",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Minimum 2-m Temperature",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "air_temperature",
+                    "standard_name": "air_temperature",
+                    "units": "deg C"
+                }
+            },
+            "tmin_station_influence": {
+                "type": "data",
+                "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "none",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "station_influence",
+                    "standard_name": "station_influence",
+                    "units": "none"
+                }
+            },
+            "vap": {
+                "type": "data",
+                "description": "2-m Vapor Pressure",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "kPa",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "2-m Vapor Pressure",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "water_vapor_partial_pressure_in_air",
+                    "standard_name": "water_vapor_partial_pressure_in_air",
+                    "units": "kPa"
+                }
+            },
+            "vap_station_influence": {
+                "type": "data",
+                "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "none",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "station_influence",
+                    "standard_name": "station_influence",
+                    "units": "none"
+                }
+            },
+            "vpd": {
+                "type": "data",
+                "description": "Mean Vapor Pressure Deficit",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "kPa",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Mean Vapor Pressure Deficit",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "vapor_pressure_deficit",
+                    "standard_name": "vapor_pressure_deficit",
+                    "units": "kPa"
+                }
+            },
+            "ws": {
+                "type": "data",
+                "description": "10-m Wind Speed",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "m/s",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "10-m Wind Speed",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "wind_speed",
+                    "standard_name": "wind_speed",
+                    "units": "m/s"
+                }
+            }
+        },
+        "datetime": "2021-01-01T00:00:00Z",
+        "start_datetime": "1958-01-01T00:00:00Z",
+        "end_datetime": "2019-12-01T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    179.97916666666666,
+                    -89.97916666666664
+                ],
+                [
+                    179.97916666666666,
+                    89.97916666666667
+                ],
+                [
+                    -179.97916666666666,
+                    89.97916666666667
+                ],
+                [
+                    -179.97916666666666,
+                    -89.97916666666664
+                ],
+                [
+                    179.97916666666666,
+                    -89.97916666666664
+                ]
+            ]
+        ]
+    },
+    "links": [],
+    "assets": {
+        "zarr-https": {
+            "href": "https://ai4edataeuwest.blob.core.windows.net/gridmet/gridmet.zarr",
+            "title": "gridMET HTTPS Zarr root",
+            "description": "HTTPS URI of the gridMET Zarr Group on Azure Blob Storage.",
+            "roles": [
+                "data",
+                "zarr",
+                "https"
+            ],
+            "type": "application/vnd+zarr",
+            "xarray:open_kwargs": {
+                "consolidated": true
+            }
+        },
+        "zarr-abfs": {
+            "href": "abfs://gridmet/gridmet.zarr",
+            "type": "application/vnd+zarr",
+            "description": "Azure Blob File System URI of the gridMET Zarr Group on Azure Blob Storage for use with adlfs.",
+            "roles": [
+                "data",
+                "zarr"
+            ],
+            "xarray:storage_options": {
+                "account_name": "ai4edataeuwest"
+            },
+            "xarray:open_kwargs": {
+                "consolidated": true
+            }
+        }
+    },
+    "bbox": [
+        -179.97916666666666,
+        -89.97916666666664,
+        179.97916666666666,
+        89.97916666666667
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
+    ]
+}

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -3,6 +3,7 @@ import json
 from typing import Any, Dict
 import unittest
 from urllib.parse import parse_qs, urlparse
+from pathlib import Path
 import warnings
 
 import requests
@@ -31,18 +32,26 @@ SENTINEL_THUMBNAIL = (
 )
 
 PC_SEARCH_URL = "https://planetarycomputer.microsoft.com/api/stac/v1/search"
-
+HERE = Path(__file__).parent
 
 def get_sample_item_dict() -> Dict[str, Any]:
-    file_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "data-files/sample-item.json")
-    )
+    file_path = HERE.joinpath("data-files/sample-item.json").absolute()
     with open(file_path) as json_file:
         return json.load(json_file)
 
 
 def get_sample_item() -> Item:
     return Item.from_dict(get_sample_item_dict())
+
+
+def get_sample_zarr_item() -> Item:
+    file_path = os.fspath(HERE.joinpath("data-files/sample-zarr-item.json"))
+    return Item.from_file(file_path)
+
+
+def get_sample_tabular_item() -> Item:
+    file_path = os.fspath(HERE.joinpath("data-files/sample-tabular-item.json"))
+    return Item.from_file(file_path)
 
 
 def get_sample_item_collection() -> ItemCollection:
@@ -141,6 +150,16 @@ class TestSigning(unittest.TestCase):
         result2 = get_token(account_name=ACCOUNT_NAME, container_name=CONTAINER_NAME)
         self.assertIs(result, result2)
 
+    def test_sign_zarr_item(self):
+        item = get_sample_zarr_item()
+        result = pc.sign(item)
+        self.assertIn("credential", result.assets["zarr-abfs"].extra_fields["xarray:storage_options"])
+
+    def test_sign_tabular_item(self):
+        item = get_sample_tabular_item()
+        result = pc.sign(item)
+        self.assertIn("credential", result.assets["data"].extra_fields["table:storage_options"])
+
 
 class TestUtils(unittest.TestCase):
     def test_parse_adlfs_url(self) -> None:
@@ -166,6 +185,21 @@ class TestUtils(unittest.TestCase):
         asset = Asset(
             "adlfs://my-container/my/path.ext",
             extra_fields={"table:storage_options": {}},
+        )
+        self.assertFalse(is_fsspec_asset(asset))
+
+        asset = Asset("adlfs://my-container/my/path.ext")
+        self.assertFalse(is_fsspec_asset(asset))
+
+        asset = Asset(
+            "adlfs://my-container/my/path.ext",
+            extra_fields={"xarray:storage_options": {"account_name": "foo"}},
+        )
+        self.assertTrue(is_fsspec_asset(asset))
+
+        asset = Asset(
+            "adlfs://my-container/my/path.ext",
+            extra_fields={"xarray:storage_options": {}},
         )
         self.assertFalse(is_fsspec_asset(asset))
 

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -34,6 +34,7 @@ SENTINEL_THUMBNAIL = (
 PC_SEARCH_URL = "https://planetarycomputer.microsoft.com/api/stac/v1/search"
 HERE = Path(__file__).parent
 
+
 def get_sample_item_dict() -> Dict[str, Any]:
     file_path = HERE.joinpath("data-files/sample-item.json").absolute()
     with open(file_path) as json_file:
@@ -150,15 +151,20 @@ class TestSigning(unittest.TestCase):
         result2 = get_token(account_name=ACCOUNT_NAME, container_name=CONTAINER_NAME)
         self.assertIs(result, result2)
 
-    def test_sign_zarr_item(self):
+    def test_sign_zarr_item(self) -> None:
         item = get_sample_zarr_item()
         result = pc.sign(item)
-        self.assertIn("credential", result.assets["zarr-abfs"].extra_fields["xarray:storage_options"])
+        self.assertIn(
+            "credential",
+            result.assets["zarr-abfs"].extra_fields["xarray:storage_options"],
+        )
 
-    def test_sign_tabular_item(self):
+    def test_sign_tabular_item(self) -> None:
         item = get_sample_tabular_item()
         result = pc.sign(item)
-        self.assertIn("credential", result.assets["data"].extra_fields["table:storage_options"])
+        self.assertIn(
+            "credential", result.assets["data"].extra_fields["table:storage_options"]
+        )
 
 
 class TestUtils(unittest.TestCase):


### PR DESCRIPTION
This adds support for signing assets that point to Zarr datasets in
Azure Blob Storage. We look for assets with `xarray:storage_options`
and, if present, add a `credential` field with the read-only SAS token.

These can then be passed along to fsspec / xarray, as recommended in
https://planetarycomputer.microsoft.com/docs/quickstarts/reading-zarr-data/.

I also upped the test covereage for Zarr and tabular datasets.

Example:

```python
In [1]: import pystac, planetary_computer, fsspec, xarray as xr

In [2]: collection = pystac.read_file("https://raw.githubusercontent.com/TomAugspurger/xstac/main/examples/gridmet/collection.json")

In [3]: asset = planetary_computer.sign(collection.assets["zarr-abfs"])

In [4]: store = fsspec.get_mapper(asset.href, **asset.extra_fields["xarray:storage_options"])
   ...: ds = xr.open_zarr(store, **asset.extra_fields["xarray:open_kwargs"])
   ...: ds
Out[4]:
<xarray.Dataset>
Dimensions:                                    (crs: 1, lat: 585, lon: 1386, time: 15341)
Coordinates:
  * crs                                        (crs) uint16 3
  * lat                                        (lat) float64 49.4 ... 25.07
  * lon                                        (lon) float64 -124.8 ... -67.06
  * time                                       (time) datetime64[ns] 1979-01-...
Data variables:
    air_temperature                            (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    burning_index_g                            (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    dead_fuel_moisture_1000hr                  (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    dead_fuel_moisture_100hr                   (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    mean_vapor_pressure_deficit                (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    potential_evapotranspiration               (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    precipitation_amount                       (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    relative_humidity                          (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    specific_humidity                          (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    surface_downwelling_shortwave_flux_in_air  (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    wind_from_direction                        (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
    wind_speed                                 (time, lat, lon) float32 dask.array<chunksize=(30, 585, 1386), meta=np.ndarray>
Attributes: (12/19)
    Conventions:                CF-1.6
    author:                     John Abatzoglou - University of Idaho, jabatz...
    coordinate_system:          EPSG:4326
    date:                       02 July 2019
    geospatial_bounds:          POLYGON((-124.7666666333333 49.40000000000000...
    geospatial_bounds_crs:      EPSG:4326
    ...                         ...
    geospatial_lon_units:       decimal_degrees east
    note1:                      The projection information for this file is: ...
    note2:                      Citation: Abatzoglou, J.T., 2013, Development...
    note3:                      Data in slices after last_permanent_slice (1-...
    note4:                      Data in slices after last_provisional_slice (...
    note5:                      Days correspond approximately to calendar day...
```