### PR TITLE
PERF: maintain root when signing ItemCollections

### DIFF
--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -179,12 +179,11 @@ def sign_item_collection(item_collection: ItemCollection) -> ItemCollection:
         a "msft:expiry" property is added to the Item properties indicating the
         earliest expiry time for any assets that were signed.
     """
-    return ItemCollection.from_dict(
-        {
-            "type": "FeatureCollection",
-            "features": [sign(item).to_dict() for item in item_collection],
-        }
-    )
+    new = item_collection.clone()
+    for item in new:
+        for key in item.assets:
+            _sign_asset_in_place(item.assets[key])
+    return new
 
 
 @sign.register(ItemSearch)

--- a/tests/data-files/catalog.json
+++ b/tests/data-files/catalog.json
@@ -1,0 +1,29 @@
+{
+  "type": "Catalog",
+  "id": "microsoft-pc-demo",
+  "stac_version": "1.0.0",
+  "description": "Microsoft Planetary Computer STAC API",
+  "links": [
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./sample-item.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./sample-tabular-item.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./sample-zarr-item.json",
+      "type": "application/json"
+    }
+  ],
+  "stac_extensions": []
+}

--- a/tests/data-files/sample-item.json
+++ b/tests/data-files/sample-item.json
@@ -105,7 +105,13 @@
             "roles": ["logo"]
         }
     },
-    "links": [],
+    "links": [
+        {
+            "rel": "root",
+            "href": "./catalog.json",
+            "type": "application/json"
+        }
+    ],
     "stac_extensions":[
         "eo",
         "projection"

--- a/tests/data-files/sample-tabular-item.json
+++ b/tests/data-files/sample-tabular-item.json
@@ -23,7 +23,13 @@
         "datetime": "2020-06-01T00:00:00Z"
     },
     "geometry": null,
-    "links": [],
+    "links": [
+        {
+            "rel": "root",
+            "href": "./catalog.json",
+            "type": "application/json"
+        }
+    ],
     "assets": {
         "data": {
             "href": "abfs://cpdata/raw/fia/plot.parquet",

--- a/tests/data-files/sample-zarr-item.json
+++ b/tests/data-files/sample-zarr-item.json
@@ -588,7 +588,13 @@
             ]
         ]
     },
-    "links": [],
+    "links": [
+        {
+            "rel": "root",
+            "href": "./catalog.json",
+            "type": "application/json"
+        }
+    ],
     "assets": {
         "zarr-https": {
             "href": "https://ai4edataeuwest.blob.core.windows.net/gridmet/gridmet.zarr",


### PR DESCRIPTION
Losing the root collection was causing `to_dict()` on signed `ItemCollections` to be extremely slow, like https://github.com/stac-utils/pystac/issues/546. By preserving the root catalog https://github.com/stac-utils/pystac-client/pull/72, it's much faster.

Before this PR:
```python
catalog = pystac_client.Client.open('https://planetarycomputer.microsoft.com/api/stac/v1')
search = catalog.search(
    collections=['landsat-8-c2-l2'],
    bbox=bbox,
    limit=10_000,
)
items = search.get_all_items()

%time _ = items.to_dict()
# Wall time: 65.8 ms

%time signed = pc.sign(items)
# Wall time: 628 ms

%time _ = signed.to_dict()
# Wall time: 1min 52s
```