### PR TITLE
Sign vrt-strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.3
+
+## New Features
+
+* `sign` will now sign VRT-like strings, like those returned by GDAL's [STACIT](https://gdal.org/drivers/raster/stacit.html) driver.
+
 # 0.4.2
 
 ## New Features

--- a/planetary_computer/__init__.py
+++ b/planetary_computer/__init__.py
@@ -11,6 +11,7 @@ from planetary_computer.sas import (
 )
 from planetary_computer.settings import set_subscription_key
 
+from planetary_computer.version import __version__
 
 __all__ = [
     "set_subscription_key",
@@ -20,4 +21,5 @@ __all__ = [
     "sign_item",
     "sign_url",
     "sign",
+    "__version__",
 ]

--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from typing import Tuple, Optional
 from urllib.parse import ParseResult, urlunparse, urlparse
 
@@ -57,3 +59,18 @@ def is_fsspec_asset(asset: pystac.Asset) -> bool:
     return "account_name" in asset.extra_fields.get(
         "table:storage_options", {}
     ) or "account_name" in asset.extra_fields.get("xarray:storage_options", {})
+
+
+def is_vrt_string(s: str) -> bool:
+    """
+    Check whether a string looks like a VRT
+    """
+    return s.strip().startswith("<VRTDataset") and s.strip().endswith("</VRTDataset>")
+
+
+asset_xpr = re.compile(
+    r"https://(?P<account>[A-z0-9]+?)"
+    r"\.blob\.core\.windows\.net/"
+    r"(?P<container>.+?)"
+    r"/(?P<blob>[^<]+)"
+)

--- a/planetary_computer/version.py
+++ b/planetary_computer/version.py
@@ -1,2 +1,3 @@
-__version__ = "0.4.2"
 """Library version"""
+
+__version__ = "0.4.3"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-black==20.8b1
-flake8==3.8.4
+black==21.10b0
+flake8==4.0.1
 ipdb==0.13.7
-mypy==0.790
-setuptools==56.0.0
+mypy==0.910
+setuptools==58.5.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,5 @@ black==21.10b0
 flake8==4.0.1
 ipdb==0.13.7
 mypy==0.910
+types-requests==2.26.0
 setuptools==58.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = planetary-computer
-version = 0.4.2
+version = 0.4.3
 license_file = LICENSE
 author = microsoft
 author_email = planetarycomputer@microsoft.com

--- a/tests/data-files/stacit.vrt
+++ b/tests/data-files/stacit.vrt
@@ -1,0 +1,886 @@
+<VRTDataset rasterXSize="161196" rasterYSize="25023">
+  <SRS dataAxisToSRSAxisMapping="1,2">PROJCS["NAD83 / UTM zone 14N",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-99],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","26914"]]</SRS>
+  <GeoTransform>  4.0896540000000002e+05,  6.0000000000000009e-01,  0.0000000000000000e+00,  4.4355894000000004e+06,  0.0000000000000000e+00, -6.0000000000000264e-01</GeoTransform>
+  <VRTRasterBand dataType="Byte" band="1">
+    <Description>Red</Description>
+    <ColorInterp>Red</ColorInterp>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909907_ne_14_060_20190709.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9845" ySize="12485" />
+      <DstRect xOff="124597" yOff="12526" xSize="9845" ySize="12485" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009963_se_14_060_20190709.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9837" ySize="12670" />
+      <DstRect xOff="124621" yOff="872" xSize="9837" ySize="12670" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009964_se_14_060_20190709.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9821" ySize="12657" />
+      <DstRect xOff="142404" yOff="897" xSize="9821" ySize="12657" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009964_sw_14_060_20190709.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9970" ySize="12663" />
+      <DstRect xOff="133442" yOff="888" xSize="9970" ySize="12663" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909907_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9995" ySize="12491" />
+      <DstRect xOff="115626" yOff="12504" xSize="9995" ySize="12491" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39100/m_3910008_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9957" ySize="12571" />
+      <DstRect xOff="0" yOff="11654" xSize="9957" ySize="12571" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909906_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10011" ySize="12503" />
+      <DstRect xOff="97827" yOff="12442" xSize="10011" ySize="12503" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909906_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9860" ySize="12497" />
+      <DstRect xOff="106798" yOff="12476" xSize="9860" ySize="12497" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909905_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10027" ySize="12516" />
+      <DstRect xOff="80027" yOff="12355" xSize="10027" ySize="12516" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909905_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9877" ySize="12509" />
+      <DstRect xOff="88998" yOff="12402" xSize="9877" ySize="12509" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909904_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10043" ySize="12529" />
+      <DstRect xOff="62228" yOff="12242" xSize="10043" ySize="12529" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909904_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9893" ySize="12522" />
+      <DstRect xOff="71199" yOff="12302" xSize="9893" ySize="12522" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909903_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10060" ySize="12542" />
+      <DstRect xOff="44428" yOff="12105" xSize="10060" ySize="12542" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909903_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9909" ySize="12534" />
+      <DstRect xOff="53399" yOff="12177" xSize="9909" ySize="12534" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909902_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10075" ySize="12554" />
+      <DstRect xOff="26629" yOff="11943" xSize="10075" ySize="12554" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909902_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9925" ySize="12546" />
+      <DstRect xOff="35600" yOff="12028" xSize="9925" ySize="12546" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909901_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10091" ySize="12567" />
+      <DstRect xOff="8829" yOff="11756" xSize="10091" ySize="12567" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909901_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9941" ySize="12559" />
+      <DstRect xOff="17800" yOff="11853" xSize="9941" ySize="12559" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009957_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9936" ySize="12744" />
+      <DstRect xOff="17920" yOff="199" xSize="9936" ySize="12744" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40100/m_4010064_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9951" ySize="12756" />
+      <DstRect xOff="137" yOff="0" xSize="9951" ySize="12756" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009963_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9988" ySize="12676" />
+      <DstRect xOff="115658" yOff="850" xSize="9988" ySize="12676" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009962_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10004" ySize="12688" />
+      <DstRect xOff="97875" yOff="788" xSize="10004" ySize="12688" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009962_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9853" ySize="12682" />
+      <DstRect xOff="106838" yOff="822" xSize="9853" ySize="12682" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009961_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10020" ySize="12701" />
+      <DstRect xOff="80092" yOff="701" xSize="10020" ySize="12701" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009961_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9870" ySize="12694" />
+      <DstRect xOff="89054" yOff="748" xSize="9870" ySize="12694" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009960_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10037" ySize="12714" />
+      <DstRect xOff="62308" yOff="588" xSize="10037" ySize="12714" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009960_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9886" ySize="12707" />
+      <DstRect xOff="71271" yOff="648" xSize="9886" ySize="12707" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009959_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10052" ySize="12726" />
+      <DstRect xOff="44525" yOff="451" xSize="10052" ySize="12726" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009959_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9902" ySize="12719" />
+      <DstRect xOff="53488" yOff="523" xSize="9902" ySize="12719" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009958_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10069" ySize="12739" />
+      <DstRect xOff="26741" yOff="289" xSize="10069" ySize="12739" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009958_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9919" ySize="12731" />
+      <DstRect xOff="35704" yOff="374" xSize="9919" ySize="12731" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009957_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10086" ySize="12751" />
+      <DstRect xOff="8957" yOff="102" xSize="10086" ySize="12751" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39098/m_3909801_nw_14_060_20190713.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9971" ySize="12472" />
+      <DstRect xOff="151225" yOff="12551" xSize="9971" ySize="12472" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40098/m_4009857_sw_14_060_20190713.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9963" ySize="12657" />
+      <DstRect xOff="151225" yOff="897" xSize="9963" ySize="12657" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909908_nw_14_060_20190828.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9979" ySize="12478" />
+      <DstRect xOff="133425" yOff="12542" xSize="9979" ySize="12478" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909908_ne_14_060_20190828.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9829" ySize="12472" />
+      <DstRect xOff="142396" yOff="12551" xSize="9829" ySize="12472" />
+    </SimpleSource>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="2">
+    <Description>Green</Description>
+    <ColorInterp>Green</ColorInterp>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909907_ne_14_060_20190709.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9845" ySize="12485" />
+      <DstRect xOff="124597" yOff="12526" xSize="9845" ySize="12485" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009963_se_14_060_20190709.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9837" ySize="12670" />
+      <DstRect xOff="124621" yOff="872" xSize="9837" ySize="12670" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009964_se_14_060_20190709.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9821" ySize="12657" />
+      <DstRect xOff="142404" yOff="897" xSize="9821" ySize="12657" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009964_sw_14_060_20190709.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9970" ySize="12663" />
+      <DstRect xOff="133442" yOff="888" xSize="9970" ySize="12663" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909907_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9995" ySize="12491" />
+      <DstRect xOff="115626" yOff="12504" xSize="9995" ySize="12491" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39100/m_3910008_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9957" ySize="12571" />
+      <DstRect xOff="0" yOff="11654" xSize="9957" ySize="12571" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909906_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10011" ySize="12503" />
+      <DstRect xOff="97827" yOff="12442" xSize="10011" ySize="12503" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909906_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9860" ySize="12497" />
+      <DstRect xOff="106798" yOff="12476" xSize="9860" ySize="12497" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909905_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10027" ySize="12516" />
+      <DstRect xOff="80027" yOff="12355" xSize="10027" ySize="12516" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909905_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9877" ySize="12509" />
+      <DstRect xOff="88998" yOff="12402" xSize="9877" ySize="12509" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909904_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10043" ySize="12529" />
+      <DstRect xOff="62228" yOff="12242" xSize="10043" ySize="12529" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909904_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9893" ySize="12522" />
+      <DstRect xOff="71199" yOff="12302" xSize="9893" ySize="12522" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909903_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10060" ySize="12542" />
+      <DstRect xOff="44428" yOff="12105" xSize="10060" ySize="12542" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909903_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9909" ySize="12534" />
+      <DstRect xOff="53399" yOff="12177" xSize="9909" ySize="12534" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909902_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10075" ySize="12554" />
+      <DstRect xOff="26629" yOff="11943" xSize="10075" ySize="12554" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909902_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9925" ySize="12546" />
+      <DstRect xOff="35600" yOff="12028" xSize="9925" ySize="12546" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909901_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10091" ySize="12567" />
+      <DstRect xOff="8829" yOff="11756" xSize="10091" ySize="12567" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909901_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9941" ySize="12559" />
+      <DstRect xOff="17800" yOff="11853" xSize="9941" ySize="12559" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009957_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9936" ySize="12744" />
+      <DstRect xOff="17920" yOff="199" xSize="9936" ySize="12744" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40100/m_4010064_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9951" ySize="12756" />
+      <DstRect xOff="137" yOff="0" xSize="9951" ySize="12756" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009963_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9988" ySize="12676" />
+      <DstRect xOff="115658" yOff="850" xSize="9988" ySize="12676" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009962_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10004" ySize="12688" />
+      <DstRect xOff="97875" yOff="788" xSize="10004" ySize="12688" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009962_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9853" ySize="12682" />
+      <DstRect xOff="106838" yOff="822" xSize="9853" ySize="12682" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009961_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10020" ySize="12701" />
+      <DstRect xOff="80092" yOff="701" xSize="10020" ySize="12701" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009961_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9870" ySize="12694" />
+      <DstRect xOff="89054" yOff="748" xSize="9870" ySize="12694" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009960_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10037" ySize="12714" />
+      <DstRect xOff="62308" yOff="588" xSize="10037" ySize="12714" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009960_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9886" ySize="12707" />
+      <DstRect xOff="71271" yOff="648" xSize="9886" ySize="12707" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009959_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10052" ySize="12726" />
+      <DstRect xOff="44525" yOff="451" xSize="10052" ySize="12726" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009959_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9902" ySize="12719" />
+      <DstRect xOff="53488" yOff="523" xSize="9902" ySize="12719" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009958_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10069" ySize="12739" />
+      <DstRect xOff="26741" yOff="289" xSize="10069" ySize="12739" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009958_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9919" ySize="12731" />
+      <DstRect xOff="35704" yOff="374" xSize="9919" ySize="12731" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009957_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10086" ySize="12751" />
+      <DstRect xOff="8957" yOff="102" xSize="10086" ySize="12751" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39098/m_3909801_nw_14_060_20190713.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9971" ySize="12472" />
+      <DstRect xOff="151225" yOff="12551" xSize="9971" ySize="12472" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40098/m_4009857_sw_14_060_20190713.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9963" ySize="12657" />
+      <DstRect xOff="151225" yOff="897" xSize="9963" ySize="12657" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909908_nw_14_060_20190828.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9979" ySize="12478" />
+      <DstRect xOff="133425" yOff="12542" xSize="9979" ySize="12478" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909908_ne_14_060_20190828.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9829" ySize="12472" />
+      <DstRect xOff="142396" yOff="12551" xSize="9829" ySize="12472" />
+    </SimpleSource>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="3">
+    <Description>Blue</Description>
+    <ColorInterp>Blue</ColorInterp>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909907_ne_14_060_20190709.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9845" ySize="12485" />
+      <DstRect xOff="124597" yOff="12526" xSize="9845" ySize="12485" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009963_se_14_060_20190709.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9837" ySize="12670" />
+      <DstRect xOff="124621" yOff="872" xSize="9837" ySize="12670" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009964_se_14_060_20190709.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9821" ySize="12657" />
+      <DstRect xOff="142404" yOff="897" xSize="9821" ySize="12657" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009964_sw_14_060_20190709.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9970" ySize="12663" />
+      <DstRect xOff="133442" yOff="888" xSize="9970" ySize="12663" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909907_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9995" ySize="12491" />
+      <DstRect xOff="115626" yOff="12504" xSize="9995" ySize="12491" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39100/m_3910008_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9957" ySize="12571" />
+      <DstRect xOff="0" yOff="11654" xSize="9957" ySize="12571" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909906_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10011" ySize="12503" />
+      <DstRect xOff="97827" yOff="12442" xSize="10011" ySize="12503" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909906_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9860" ySize="12497" />
+      <DstRect xOff="106798" yOff="12476" xSize="9860" ySize="12497" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909905_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10027" ySize="12516" />
+      <DstRect xOff="80027" yOff="12355" xSize="10027" ySize="12516" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909905_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9877" ySize="12509" />
+      <DstRect xOff="88998" yOff="12402" xSize="9877" ySize="12509" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909904_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10043" ySize="12529" />
+      <DstRect xOff="62228" yOff="12242" xSize="10043" ySize="12529" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909904_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9893" ySize="12522" />
+      <DstRect xOff="71199" yOff="12302" xSize="9893" ySize="12522" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909903_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10060" ySize="12542" />
+      <DstRect xOff="44428" yOff="12105" xSize="10060" ySize="12542" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909903_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9909" ySize="12534" />
+      <DstRect xOff="53399" yOff="12177" xSize="9909" ySize="12534" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909902_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10075" ySize="12554" />
+      <DstRect xOff="26629" yOff="11943" xSize="10075" ySize="12554" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909902_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9925" ySize="12546" />
+      <DstRect xOff="35600" yOff="12028" xSize="9925" ySize="12546" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909901_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10091" ySize="12567" />
+      <DstRect xOff="8829" yOff="11756" xSize="10091" ySize="12567" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909901_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9941" ySize="12559" />
+      <DstRect xOff="17800" yOff="11853" xSize="9941" ySize="12559" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009957_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9936" ySize="12744" />
+      <DstRect xOff="17920" yOff="199" xSize="9936" ySize="12744" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40100/m_4010064_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9951" ySize="12756" />
+      <DstRect xOff="137" yOff="0" xSize="9951" ySize="12756" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009963_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9988" ySize="12676" />
+      <DstRect xOff="115658" yOff="850" xSize="9988" ySize="12676" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009962_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10004" ySize="12688" />
+      <DstRect xOff="97875" yOff="788" xSize="10004" ySize="12688" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009962_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9853" ySize="12682" />
+      <DstRect xOff="106838" yOff="822" xSize="9853" ySize="12682" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009961_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10020" ySize="12701" />
+      <DstRect xOff="80092" yOff="701" xSize="10020" ySize="12701" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009961_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9870" ySize="12694" />
+      <DstRect xOff="89054" yOff="748" xSize="9870" ySize="12694" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009960_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10037" ySize="12714" />
+      <DstRect xOff="62308" yOff="588" xSize="10037" ySize="12714" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009960_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9886" ySize="12707" />
+      <DstRect xOff="71271" yOff="648" xSize="9886" ySize="12707" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009959_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10052" ySize="12726" />
+      <DstRect xOff="44525" yOff="451" xSize="10052" ySize="12726" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009959_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9902" ySize="12719" />
+      <DstRect xOff="53488" yOff="523" xSize="9902" ySize="12719" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009958_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10069" ySize="12739" />
+      <DstRect xOff="26741" yOff="289" xSize="10069" ySize="12739" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009958_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9919" ySize="12731" />
+      <DstRect xOff="35704" yOff="374" xSize="9919" ySize="12731" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009957_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10086" ySize="12751" />
+      <DstRect xOff="8957" yOff="102" xSize="10086" ySize="12751" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39098/m_3909801_nw_14_060_20190713.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9971" ySize="12472" />
+      <DstRect xOff="151225" yOff="12551" xSize="9971" ySize="12472" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40098/m_4009857_sw_14_060_20190713.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9963" ySize="12657" />
+      <DstRect xOff="151225" yOff="897" xSize="9963" ySize="12657" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909908_nw_14_060_20190828.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9979" ySize="12478" />
+      <DstRect xOff="133425" yOff="12542" xSize="9979" ySize="12478" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909908_ne_14_060_20190828.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9829" ySize="12472" />
+      <DstRect xOff="142396" yOff="12551" xSize="9829" ySize="12472" />
+    </SimpleSource>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="4">
+    <Metadata>
+      <MDI key="description">near-infrared</MDI>
+    </Metadata>
+    <Description>NIR</Description>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909907_ne_14_060_20190709.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9845" ySize="12485" />
+      <DstRect xOff="124597" yOff="12526" xSize="9845" ySize="12485" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009963_se_14_060_20190709.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9837" ySize="12670" />
+      <DstRect xOff="124621" yOff="872" xSize="9837" ySize="12670" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009964_se_14_060_20190709.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9821" ySize="12657" />
+      <DstRect xOff="142404" yOff="897" xSize="9821" ySize="12657" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009964_sw_14_060_20190709.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9970" ySize="12663" />
+      <DstRect xOff="133442" yOff="888" xSize="9970" ySize="12663" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909907_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9995" ySize="12491" />
+      <DstRect xOff="115626" yOff="12504" xSize="9995" ySize="12491" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39100/m_3910008_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9957" ySize="12571" />
+      <DstRect xOff="0" yOff="11654" xSize="9957" ySize="12571" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909906_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10011" ySize="12503" />
+      <DstRect xOff="97827" yOff="12442" xSize="10011" ySize="12503" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909906_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9860" ySize="12497" />
+      <DstRect xOff="106798" yOff="12476" xSize="9860" ySize="12497" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909905_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10027" ySize="12516" />
+      <DstRect xOff="80027" yOff="12355" xSize="10027" ySize="12516" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909905_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9877" ySize="12509" />
+      <DstRect xOff="88998" yOff="12402" xSize="9877" ySize="12509" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909904_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10043" ySize="12529" />
+      <DstRect xOff="62228" yOff="12242" xSize="10043" ySize="12529" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909904_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9893" ySize="12522" />
+      <DstRect xOff="71199" yOff="12302" xSize="9893" ySize="12522" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909903_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10060" ySize="12542" />
+      <DstRect xOff="44428" yOff="12105" xSize="10060" ySize="12542" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909903_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9909" ySize="12534" />
+      <DstRect xOff="53399" yOff="12177" xSize="9909" ySize="12534" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909902_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10075" ySize="12554" />
+      <DstRect xOff="26629" yOff="11943" xSize="10075" ySize="12554" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909902_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9925" ySize="12546" />
+      <DstRect xOff="35600" yOff="12028" xSize="9925" ySize="12546" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909901_nw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10091" ySize="12567" />
+      <DstRect xOff="8829" yOff="11756" xSize="10091" ySize="12567" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909901_ne_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9941" ySize="12559" />
+      <DstRect xOff="17800" yOff="11853" xSize="9941" ySize="12559" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009957_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9936" ySize="12744" />
+      <DstRect xOff="17920" yOff="199" xSize="9936" ySize="12744" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40100/m_4010064_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9951" ySize="12756" />
+      <DstRect xOff="137" yOff="0" xSize="9951" ySize="12756" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009963_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9988" ySize="12676" />
+      <DstRect xOff="115658" yOff="850" xSize="9988" ySize="12676" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009962_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10004" ySize="12688" />
+      <DstRect xOff="97875" yOff="788" xSize="10004" ySize="12688" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009962_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9853" ySize="12682" />
+      <DstRect xOff="106838" yOff="822" xSize="9853" ySize="12682" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009961_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10020" ySize="12701" />
+      <DstRect xOff="80092" yOff="701" xSize="10020" ySize="12701" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009961_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9870" ySize="12694" />
+      <DstRect xOff="89054" yOff="748" xSize="9870" ySize="12694" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009960_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10037" ySize="12714" />
+      <DstRect xOff="62308" yOff="588" xSize="10037" ySize="12714" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009960_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9886" ySize="12707" />
+      <DstRect xOff="71271" yOff="648" xSize="9886" ySize="12707" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009959_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10052" ySize="12726" />
+      <DstRect xOff="44525" yOff="451" xSize="10052" ySize="12726" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009959_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9902" ySize="12719" />
+      <DstRect xOff="53488" yOff="523" xSize="9902" ySize="12719" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009958_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10069" ySize="12739" />
+      <DstRect xOff="26741" yOff="289" xSize="10069" ySize="12739" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009958_se_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9919" ySize="12731" />
+      <DstRect xOff="35704" yOff="374" xSize="9919" ySize="12731" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40099/m_4009957_sw_14_060_20190711.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="10086" ySize="12751" />
+      <DstRect xOff="8957" yOff="102" xSize="10086" ySize="12751" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39098/m_3909801_nw_14_060_20190713.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9971" ySize="12472" />
+      <DstRect xOff="151225" yOff="12551" xSize="9971" ySize="12472" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/40098/m_4009857_sw_14_060_20190713.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9963" ySize="12657" />
+      <DstRect xOff="151225" yOff="897" xSize="9963" ySize="12657" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909908_nw_14_060_20190828.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9979" ySize="12478" />
+      <DstRect xOff="133425" yOff="12542" xSize="9979" ySize="12478" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/vsicurl/https://naipeuwest.blob.core.windows.net/naip/v002/ks/2019/ks_60cm_2019/39099/m_3909908_ne_14_060_20190828.tif</SourceFilename>
+      <SourceBand>4</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="9829" ySize="12472" />
+      <DstRect xOff="142396" yOff="12551" xSize="9829" ySize="12472" />
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -174,6 +174,12 @@ class TestSigning(unittest.TestCase):
         )
         self.assertRootResolved(item)
 
+    def test_sign_vrt(self) -> None:
+        vrt_string = Path(HERE / "data-files/stacit.vrt").read_text()
+        self.assertEqual(vrt_string.count("?st"), 0)
+        result = pc.sign(vrt_string)
+        self.assertGreater(result.count("?st"), 0)
+
 
 class TestUtils(unittest.TestCase):
     def test_parse_adlfs_url(self) -> None:


### PR DESCRIPTION
xref #32, which also includes feature requests for signing files. This handles the in-memory string portion of things.

The imagined workflow here is something like

```console
$ gdal_translate "STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\":asset=image" out.vrt
```

And then using it from Python like

```python
In [1]: import pathlib, planetary_computer, rioxarray

In [2]: signed_vrt = planetary_computer.sign(pathlib.Path("out.vrt").read_text())

In [3]: ds = rioxarray.open_rasterio(signed_vrt)

In [4]: ds
Out[4]:
<xarray.DataArray (band: 4, y: 25023, x: 161196)>
[16134430032 values with dtype=uint8]
Coordinates:
  * band         (band) int64 1 2 3 4
  * x            (x) float64 4.09e+05 4.09e+05 4.09e+05 ... 5.057e+05 5.057e+05
  * y            (y) float64 4.436e+06 4.436e+06 ... 4.421e+06 4.421e+06
    spatial_ref  int64 0
Attributes:
    scale_factor:  1.0
    add_offset:    0.0
    long_name:     ('Red', 'Green', 'Blue', 'NIR')
```
