### PR TITLE
ENH: Sign storage_options in xarray:open_kwargs

### DIFF
--- a/planetary_computer/utils.py
+++ b/planetary_computer/utils.py
@@ -53,12 +53,31 @@ def is_fsspec_asset(asset: pystac.Asset) -> bool:
     """
     Determine if an Asset points to an fsspec URL.
 
-    This checks if "account_name" is present in the asset's "table:storage_options"
-    or "xarray:storage_options" fields.
+    This checks if "account_name" is present in the asset's
+
+    * "table:storage_options"
+    * "xarray:storage_options"
+    * "xarray:open_kwargs.storage_options"
+    * "xarray:open_kwargs.backend_kwargs.storage_options"
     """
-    return "account_name" in asset.extra_fields.get(
-        "table:storage_options", {}
-    ) or "account_name" in asset.extra_fields.get("xarray:storage_options", {})
+    result = (
+        ("account_name" in asset.extra_fields.get("table:storage_options", {}))
+        or ("account_name" in asset.extra_fields.get("xarray:storage_options", {}))
+        or (
+            "account_name"
+            in asset.extra_fields.get("xarray:open_kwargs", {}).get(
+                "storage_options", {}
+            )
+        )
+        or (
+            "account_name"
+            in asset.extra_fields.get("xarray:open_kwargs", {})
+            .get("backend_kwargs", {})
+            .get("storage_options", {})
+        )
+    )
+
+    return result
 
 
 def is_vrt_string(s: str) -> bool:

--- a/tests/data-files/sample-zarr-open-dataset-item.json
+++ b/tests/data-files/sample-zarr-open-dataset-item.json
@@ -1,0 +1,642 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "terraclimate",
+    "properties": {
+        "cube:dimensions": {
+            "time": {
+                "type": "temporal",
+                "description": "time",
+                "extent": [
+                    "1958-01-01T00:00:00Z",
+                    "2019-12-01T00:00:00Z"
+                ]
+            },
+            "lon": {
+                "type": "spatial",
+                "axis": "x",
+                "description": "longitude",
+                "extent": [
+                    -179.97916666666666,
+                    179.97916666666666
+                ],
+                "reference_system": 4326
+            },
+            "lat": {
+                "type": "spatial",
+                "axis": "y",
+                "description": "latitude",
+                "extent": [
+                    -89.97916666666664,
+                    89.97916666666667
+                ],
+                "reference_system": 4326
+            }
+        },
+        "cube:variables": {
+            "aet": {
+                "type": "data",
+                "description": "Actual Evapotranspiration",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Actual Evapotranspiration",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "water_evaporation_amount",
+                    "standard_name": "water_evaporation_amount",
+                    "units": "mm"
+                }
+            },
+            "def": {
+                "type": "data",
+                "description": "Climatic Water Deficit",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Climatic Water Deficit",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "water_potential_evaporation_amount_minus_water_evaporation_amount",
+                    "standard_name": "water_potential_evaporation_amount_minus_water_evaporation_amount",
+                    "units": "mm"
+                }
+            },
+            "pdsi": {
+                "type": "data",
+                "description": "Palmer Drought Severity Index",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "unitless",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Palmer Drought Severity Index",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "palmer_drought_severity_index",
+                    "standard_name": "palmer_drought_severity_index",
+                    "units": "unitless"
+                }
+            },
+            "pet": {
+                "type": "data",
+                "description": "Reference Evapotranspiration",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Reference Evapotranspiration",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "water_potential_evaporation_amount",
+                    "standard_name": "water_potential_evaporation_amount",
+                    "units": "mm"
+                }
+            },
+            "ppt": {
+                "type": "data",
+                "description": "Accumulated Precipitation",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Accumulated Precipitation",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "precipitation_amount",
+                    "standard_name": "precipitation_amount",
+                    "units": "mm"
+                }
+            },
+            "ppt_station_influence": {
+                "type": "data",
+                "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "none",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "station_influence",
+                    "standard_name": "station_influence",
+                    "units": "none"
+                }
+            },
+            "q": {
+                "type": "data",
+                "description": "Runoff",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Runoff",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "runoff_amount",
+                    "standard_name": "runoff_amount",
+                    "units": "mm"
+                }
+            },
+            "soil": {
+                "type": "data",
+                "description": "Soil Moisture at End of Month",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Soil Moisture at End of Month",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "soil_moisture_content",
+                    "standard_name": "soil_moisture_content",
+                    "units": "mm"
+                }
+            },
+            "srad": {
+                "type": "data",
+                "description": "Downward Shortwave Radiation Flux at the Surface",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "W/m2",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Downward Shortwave Radiation Flux at the Surface",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "downwelling_shortwave_flux_in_air",
+                    "standard_name": "downwelling_shortwave_flux_in_air",
+                    "units": "W/m2"
+                }
+            },
+            "swe": {
+                "type": "data",
+                "description": "Snow Water Equivalent at End of Month",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "mm",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Snow Water Equivalent at End of Month",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "liquid_water_content_of_surface_snow",
+                    "standard_name": "liquid_water_content_of_surface_snow",
+                    "units": "mm"
+                }
+            },
+            "tmax": {
+                "type": "data",
+                "description": "Maximum 2-m Temperature",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "deg C",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Maximum 2-m Temperature",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "air_temperature",
+                    "standard_name": "air_temperature",
+                    "units": "deg C"
+                }
+            },
+            "tmax_station_influence": {
+                "type": "data",
+                "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "none",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "station_influence",
+                    "standard_name": "station_influence",
+                    "units": "none"
+                }
+            },
+            "tmin": {
+                "type": "data",
+                "description": "Minimum 2-m Temperature",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "deg C",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Minimum 2-m Temperature",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "air_temperature",
+                    "standard_name": "air_temperature",
+                    "units": "deg C"
+                }
+            },
+            "tmin_station_influence": {
+                "type": "data",
+                "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "none",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "station_influence",
+                    "standard_name": "station_influence",
+                    "units": "none"
+                }
+            },
+            "vap": {
+                "type": "data",
+                "description": "2-m Vapor Pressure",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "kPa",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "2-m Vapor Pressure",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "water_vapor_partial_pressure_in_air",
+                    "standard_name": "water_vapor_partial_pressure_in_air",
+                    "units": "kPa"
+                }
+            },
+            "vap_station_influence": {
+                "type": "data",
+                "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "none",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "A number between 0 and 8, indicating the number of stations contributing to each grid value directly from CRU and interpolated to the TerraClimate grid. When this value is greater than 1, CRU data is used for the anomalies in the method. When this value is 0, JRA-55/ERA-20C/ERA-INTERIM is used for anomalies in the method.",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "station_influence",
+                    "standard_name": "station_influence",
+                    "units": "none"
+                }
+            },
+            "vpd": {
+                "type": "data",
+                "description": "Mean Vapor Pressure Deficit",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "kPa",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "Mean Vapor Pressure Deficit",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "vapor_pressure_deficit",
+                    "standard_name": "vapor_pressure_deficit",
+                    "units": "kPa"
+                }
+            },
+            "ws": {
+                "type": "data",
+                "description": "10-m Wind Speed",
+                "dimensions": [
+                    "time",
+                    "lat",
+                    "lon"
+                ],
+                "unit": "m/s",
+                "shape": [
+                    744,
+                    4320,
+                    8640
+                ],
+                "chunks": [
+                    12,
+                    1440,
+                    1440
+                ],
+                "attrs": {
+                    "coordinate_system": "WGS84,EPSG:4326",
+                    "description": "10-m Wind Speed",
+                    "dimensions": "lon lat time",
+                    "grid_mapping": "crs",
+                    "long_name": "wind_speed",
+                    "standard_name": "wind_speed",
+                    "units": "m/s"
+                }
+            }
+        },
+        "datetime": "2021-01-01T00:00:00Z",
+        "start_datetime": "1958-01-01T00:00:00Z",
+        "end_datetime": "2019-12-01T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    179.97916666666666,
+                    -89.97916666666664
+                ],
+                [
+                    179.97916666666666,
+                    89.97916666666667
+                ],
+                [
+                    -179.97916666666666,
+                    89.97916666666667
+                ],
+                [
+                    -179.97916666666666,
+                    -89.97916666666664
+                ],
+                [
+                    179.97916666666666,
+                    -89.97916666666664
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "./catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "zarr-https": {
+            "href": "https://ai4edataeuwest.blob.core.windows.net/gridmet/gridmet.zarr",
+            "title": "gridMET HTTPS Zarr root",
+            "description": "HTTPS URI of the gridMET Zarr Group on Azure Blob Storage.",
+            "roles": [
+                "data",
+                "zarr",
+                "https"
+            ],
+            "type": "application/vnd+zarr",
+            "xarray:open_kwargs": {
+                "consolidated": true
+            }
+        },
+        "zarr-abfs": {
+            "href": "abfs://gridmet/gridmet.zarr",
+            "type": "application/vnd+zarr",
+            "description": "Azure Blob File System URI of the gridMET Zarr Group on Azure Blob Storage for use with adlfs.",
+            "roles": [
+                "data",
+                "zarr"
+            ],
+            "xarray:open_kwargs": {
+                "engine": "zarr",
+                "chunks": {},
+                "storage_options": {
+                    "account_name": "ai4edataeuwest"
+                },
+                "backend_kwargs": {
+                    "consolidated": true
+                }
+            }
+        }
+    },
+    "bbox": [
+        -179.97916666666666,
+        -89.97916666666664,
+        179.97916666666666,
+        89.97916666666667
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
+    ]
+}

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -50,7 +50,9 @@ def get_sample_zarr_item() -> Item:
 
 
 def get_sample_zarr_open_dataset_item() -> Item:
-    file_path = os.fspath(HERE.joinpath("data-files/sample-zarr-open-dataset-item.json"))
+    file_path = os.fspath(
+        HERE.joinpath("data-files/sample-zarr-open-dataset-item.json")
+    )
     return resolve(Item.from_file(file_path))
 
 
@@ -183,7 +185,9 @@ class TestSigning(unittest.TestCase):
         result = pc.sign(item)
         self.assertIn(
             "credential",
-            result.assets["zarr-abfs"].extra_fields["xarray:open_kwargs"]["storage_options"],
+            result.assets["zarr-abfs"].extra_fields["xarray:open_kwargs"][
+                "storage_options"
+            ],
         )
         self.assertRootResolved(item)
 
@@ -191,18 +195,18 @@ class TestSigning(unittest.TestCase):
         # nest inside backend_kwargs
         item = get_sample_zarr_open_dataset_item()
         extra_fields = item.assets["zarr-abfs"].extra_fields
-        extra_fields["xarray:open_kwargs"]["backend_kwargs"]["storage_options"] = (
-            extra_fields["xarray:open_kwargs"].pop("storage_options")
-        )
+        extra_fields["xarray:open_kwargs"]["backend_kwargs"][
+            "storage_options"
+        ] = extra_fields["xarray:open_kwargs"].pop("storage_options")
 
         result = pc.sign(item)
         self.assertIn(
             "credential",
-            result.assets["zarr-abfs"].extra_fields["xarray:open_kwargs"]["backend_kwargs"]["storage_options"],
+            result.assets["zarr-abfs"].extra_fields["xarray:open_kwargs"][
+                "backend_kwargs"
+            ]["storage_options"],
         )
         self.assertRootResolved(item)
-
-
 
     def test_sign_tabular_item(self) -> None:
         item = get_sample_tabular_item()

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -49,6 +49,11 @@ def get_sample_zarr_item() -> Item:
     return resolve(Item.from_file(file_path))
 
 
+def get_sample_zarr_open_dataset_item() -> Item:
+    file_path = os.fspath(HERE.joinpath("data-files/sample-zarr-open-dataset-item.json"))
+    return resolve(Item.from_file(file_path))
+
+
 def get_sample_tabular_item() -> Item:
     file_path = os.fspath(HERE.joinpath("data-files/sample-tabular-item.json"))
     return resolve(Item.from_file(file_path))
@@ -172,6 +177,32 @@ class TestSigning(unittest.TestCase):
             result.assets["zarr-abfs"].extra_fields["xarray:storage_options"],
         )
         self.assertRootResolved(item)
+
+    def test_sign_zarr_open_dataset_item(self) -> None:
+        item = get_sample_zarr_open_dataset_item()
+        result = pc.sign(item)
+        self.assertIn(
+            "credential",
+            result.assets["zarr-abfs"].extra_fields["xarray:open_kwargs"]["storage_options"],
+        )
+        self.assertRootResolved(item)
+
+    def test_sign_zarr_open_dataset_nested_item(self) -> None:
+        # nest inside backend_kwargs
+        item = get_sample_zarr_open_dataset_item()
+        extra_fields = item.assets["zarr-abfs"].extra_fields
+        extra_fields["xarray:open_kwargs"]["backend_kwargs"]["storage_options"] = (
+            extra_fields["xarray:open_kwargs"].pop("storage_options")
+        )
+
+        result = pc.sign(item)
+        self.assertIn(
+            "credential",
+            result.assets["zarr-abfs"].extra_fields["xarray:open_kwargs"]["backend_kwargs"]["storage_options"],
+        )
+        self.assertRootResolved(item)
+
+
 
     def test_sign_tabular_item(self) -> None:
         item = get_sample_tabular_item()


### PR DESCRIPTION
Recent-ish versions of xarray natively support expanding fsspec URLs
and forwarding storage options. This enables

```python
>>> ds = xr.open_dataset(asset.href, **asset.extra_fields["xarray:open_kwargs"])
```

rather than the wordier

```python
>>> store = fsspec.get_mapper(asset.href, **asset.extra_fields["xarray:storage_options"])
>>> ds = xr.open_dataset(store, **asset.extra_fields["xarray:open_kwargs])
```

This PR supports signing the version of assets where storage_options are nested under `xarray:open_kwargs` or `xarray:open_kwargs.backend_kwargs`.