### PR TITLE
Feature/no double sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.7
+
+## New Features
+
+* `sign` will now avoid signing URLs that have already been signed.
+
 # 0.4.6
 
 ## New Features

--- a/planetary_computer/sas.py
+++ b/planetary_computer/sas.py
@@ -6,7 +6,7 @@ import copy
 import warnings
 
 from functools import singledispatch
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 import requests
 from pydantic import BaseModel, Field
 from pystac import Asset, Item, ItemCollection
@@ -124,6 +124,11 @@ def sign_url(url: str) -> str:
     """
     parsed_url = urlparse(url.rstrip("/"))
     if not parsed_url.netloc.endswith(BLOB_STORAGE_DOMAIN):
+        return url
+
+    parsed_qs = parse_qs(parsed_url.query)
+    if set(parsed_qs) & {"st", "se", "sp"}:
+        #  looks like we've already signed it
         return url
 
     account, container = parse_blob_url(parsed_url)

--- a/planetary_computer/version.py
+++ b/planetary_computer/version.py
@@ -1,3 +1,3 @@
 """Library version"""
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-black==21.10b0
+black==22.6.0
 flake8==4.0.1
-ipdb==0.13.7
-mypy==0.910
-types-requests==2.26.0
-setuptools==58.5.3
+ipdb==0.13.9
+mypy==0.961
+types-requests==2.28.1
+setuptools==63.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = planetary-computer
-version = 0.4.6
+version = 0.4.7
 license_file = LICENSE
 author = microsoft
 author_email = planetarycomputer@microsoft.com

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -283,3 +283,8 @@ class TestUtils(unittest.TestCase):
 
         asset = Asset("adlfs://my-container/my/path.ext")
         self.assertFalse(is_fsspec_asset(asset))
+
+    def test_no_double_sign_url(self) -> None:
+        result = pc.sign(SENTINEL_THUMBNAIL)
+        result2 = pc.sign(result)
+        assert result == result2


### PR DESCRIPTION
Avoids double-signing URLs by parsing the URL's querystring to look for markers of a SAS token.

Closes #21 